### PR TITLE
Bumped roar.

### DIFF
--- a/cmake/dependencies/roar.cmake
+++ b/cmake/dependencies/roar.cmake
@@ -4,7 +4,7 @@ include(FetchContent)
 FetchContent_Declare(
 	roar
 	GIT_REPOSITORY https://github.com/5cript/roar.git
-	GIT_TAG        49155256244a6d4fd24f3110222898d7f423570b
+	GIT_TAG        560f5cd4ea59fb4f9e667aed485b52794680adcf
 )
 
 FetchContent_MakeAvailable(roar)


### PR DESCRIPTION
To avoid clang bug in boost beast.
https://github.com/boostorg/beast/issues/2661