### PR TITLE
Useability Improvements

### DIFF
--- a/nui/include/nui/frontend/elements/impl/html_element.hpp
+++ b/nui/include/nui/frontend/elements/impl/html_element.hpp
@@ -269,7 +269,7 @@ namespace Nui
                         {
                             parent->clearChildren();
                             long counter = 0;
-                            for (auto const& element : observedValue.value())
+                            for (auto& element : observedValue.value())
                                 ElementRenderer(counter++, element)(*parent, Renderer{.type = RendererType::Append});
                             return;
                         }
@@ -341,9 +341,9 @@ namespace Nui
         // Children functions:
         template <typename... ElementT>
         requires requires(ElementT&&... elements) {
-            std::vector<std::function<std::shared_ptr<Dom::Element>(Dom::Element&, Renderer const&)>>{
-                std::forward<ElementT>(elements)...};
-        }
+                     std::vector<std::function<std::shared_ptr<Dom::Element>(Dom::Element&, Renderer const&)>>{
+                         std::forward<ElementT>(elements)...};
+                 }
         constexpr auto operator()(ElementT&&... elements) &&
         {
             return std::function<std::shared_ptr<Dom::Element>(Dom::Element&, Renderer const&)>{

--- a/nui/include/nui/frontend/event_system/observed_value.hpp
+++ b/nui/include/nui/frontend/event_system/observed_value.hpp
@@ -551,6 +551,7 @@ namespace Nui
         ~ObservedContainer() = default;
 
         constexpr auto map(auto&& function) const;
+        constexpr auto map(auto&& function);
 
         template <typename T = ContainerT>
         ObservedContainer& operator=(T&& t)
@@ -1045,6 +1046,14 @@ namespace Nui
     {
         return std::pair<ObservedRange<Observed<ContainerT>>, std::decay_t<decltype(function)>>{
             ObservedRange<Observed<ContainerT>>{static_cast<Observed<ContainerT> const&>(*this)},
+            std::forward<std::decay_t<decltype(function)>>(function),
+        };
+    }
+    template <typename ContainerT>
+    constexpr auto ObservedContainer<ContainerT>::map(auto&& function)
+    {
+        return std::pair<ObservedRange<Observed<ContainerT>>, std::decay_t<decltype(function)>>{
+            ObservedRange<Observed<ContainerT>>{static_cast<Observed<ContainerT>&>(*this)},
             std::forward<std::decay_t<decltype(function)>>(function),
         };
     }

--- a/nui/include/nui/frontend/event_system/range.hpp
+++ b/nui/include/nui/frontend/event_system/range.hpp
@@ -6,7 +6,7 @@ namespace Nui
     class ObservedRange
     {
       public:
-        constexpr ObservedRange(ObservedValue const& observedValues)
+        constexpr ObservedRange(ObservedValue& observedValues)
             : observedValue_{observedValues}
         {}
 
@@ -14,14 +14,25 @@ namespace Nui
         {
             return observedValue_;
         }
+        ObservedValue& observedValue()
+        requires(!std::is_const_v<ObservedValue>)
+        {
+            return observedValue_;
+        }
 
       private:
-        ObservedValue const& observedValue_;
+        ObservedValue& observedValue_;
     };
 
     template <typename ObservedValue>
-    ObservedRange<ObservedValue> range(ObservedValue const& observedValues)
+    ObservedRange<ObservedValue> range(ObservedValue& observedValues)
     {
         return ObservedRange<ObservedValue>{observedValues};
+    }
+
+    template <typename ObservedValue>
+    ObservedRange<const ObservedValue> range(ObservedValue const& observedValues)
+    {
+        return ObservedRange<const ObservedValue>{observedValues};
     }
 }


### PR DESCRIPTION
- Range render functions can now take non-const references to elements, which is useful in some cases.
- Added some val conversions for convenience.