### PR TITLE
Added support for dispatch and mutable rpc lambdas.

### DIFF
--- a/nui/include/nui/backend/rpc_hub.hpp
+++ b/nui/include/nui/backend/rpc_hub.hpp
@@ -40,7 +40,7 @@ namespace Nui
             template <typename FunctionT>
             constexpr static auto wrapFunction(FunctionT&& func)
             {
-                return [func = std::move(func)](nlohmann::json const& args) {
+                return [func = std::move(func)](nlohmann::json const& args) mutable {
                     func(args);
                 };
             }
@@ -52,7 +52,7 @@ namespace Nui
             template <typename FunctionT>
             constexpr static auto wrapFunction(FunctionT&& func)
             {
-                return [func = std::move(func)](nlohmann::json const& args) {
+                return [func = std::move(func)](nlohmann::json const& args) mutable {
                     func(extractJsonMember<ArgsTypes>(args[Is])...);
                 };
             }

--- a/nui/include/nui/window.hpp
+++ b/nui/include/nui/window.hpp
@@ -284,6 +284,13 @@ namespace Nui
         void run();
 
         /**
+         * @brief Run a function on the main thread
+         *
+         * @param func
+         */
+        void dispatch(std::function<void()> func);
+
+        /**
          * @brief Set page html from a string.
          *
          * @param html Page html.

--- a/nui/src/nui/backend/window.cpp
+++ b/nui/src/nui/backend/window.cpp
@@ -428,6 +428,12 @@ namespace Nui
         impl_->view->navigate("file://"s + file.string());
     }
     //---------------------------------------------------------------------------------------------------------------------
+    void Window::dispatch(std::function<void()> func)
+    {
+        std::scoped_lock lock{impl_->viewGuard};
+        impl_->view->dispatch(std::move(func));
+    }
+    //---------------------------------------------------------------------------------------------------------------------
     void Window::run()
     {
 #ifdef _WIN32


### PR DESCRIPTION
This now works:
`rpcHub.registerFunction("bla", []() mutable {});`

And this was added:
```cpp
Window wnd{/*...*/};
wnd.dispatch([](){
  // run in main thread.
});
```