### PR TITLE
Fixed dangling reference to function.

### DIFF
--- a/nui/include/nui/frontend/attributes/reference.hpp
+++ b/nui/include/nui/frontend/attributes/reference.hpp
@@ -19,7 +19,7 @@ namespace Nui::Attributes
         requires std::invocable<T, Nui::val&&>
         Attribute onMaterialize(T&& func) const
         {
-            return operator=([&func](std::weak_ptr<Dom::BasicElement>&& element) {
+            return operator=([func = std::forward<T>(func)](std::weak_ptr<Dom::BasicElement>&& element) {
                 func(element.lock()->val());
             });
         }


### PR DESCRIPTION
The following code leads to a dangling reference to an rvalue function:
```C++
div {
  reference.onMaterialize([](Nui::val){/*...*/})
}()
```
This PR fixes this.