### PR TITLE
Require observed for observe for better diagnostics.

### DIFF
--- a/nui/include/nui/frontend/event_system/observed_value_combinator.hpp
+++ b/nui/include/nui/frontend/event_system/observed_value_combinator.hpp
@@ -141,6 +141,7 @@ namespace Nui
     ObservedValueCombinator(ObservedValues const&...) -> ObservedValueCombinator<ObservedValues...>;
 
     template <typename... ObservedValues>
+    requires(Detail::IsObserved<ObservedValues>::value && ...)
     ObservedValueCombinator<ObservedValues...> observe(ObservedValues const&... observedValues)
     {
         return ObservedValueCombinator(observedValues...);


### PR DESCRIPTION
To get better error messages, when the user tries this:

```c++
std::string notObservable;
div{
  class_ = observe(notObservable).generate([](){}), // invalid use of observe()
}()
```

observe is now constrained by IsObserved<T>