### PR TITLE
Added flag to Observed<> ctor.

### DIFF
--- a/nui/include/nui/utility/assert.hpp
+++ b/nui/include/nui/utility/assert.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <nui/frontend/val.hpp>
+
+#include <stdexcept>
+
+namespace Nui
+{
+    inline void assertImpl(bool condition, const char* message)
+    {
+        if (!condition)
+        {
+#ifdef __cpp_exceptions
+            throw std::runtime_error(message);
+#else
+            Nui::val::global("console").call<void>("error", message);
+#endif
+        }
+    }
+
+#ifdef NDEBUG
+#    define NUI_ASSERT(condition, message)
+#else
+#    define NUI_ASSERT(condition, message) assertImpl(condition, message)
+#endif
+}

--- a/nui/test/nui/test_events.hpp
+++ b/nui/test/nui/test_events.hpp
@@ -144,7 +144,7 @@ namespace Nui::Tests
     {
         EventContext eventContext;
 
-        Observed<int> obs{&eventContext};
+        Observed<int> obs{CustomEventContextFlag, &eventContext};
 
         int calledWith = 77;
         listen(eventContext, obs, [&calledWith](int const& value) -> bool {
@@ -162,7 +162,7 @@ namespace Nui::Tests
     {
         EventContext eventContext;
 
-        Observed<int> obs{&eventContext};
+        Observed<int> obs{CustomEventContextFlag, &eventContext};
 
         int calledWith = 77;
         listen(eventContext, obs, [&calledWith](int const& value) -> void {
@@ -179,7 +179,7 @@ namespace Nui::Tests
     {
         EventContext eventContext;
 
-        std::shared_ptr<Observed<int>> obs = std::make_shared<Observed<int>>(&eventContext);
+        std::shared_ptr<Observed<int>> obs = std::make_shared<Observed<int>>(CustomEventContextFlag, &eventContext);
 
         int calledWith = 77;
         listen(eventContext, obs, [&calledWith](int const& value) -> void {
@@ -196,7 +196,7 @@ namespace Nui::Tests
     {
         EventContext eventContext;
 
-        std::shared_ptr<Observed<int>> obs = std::make_shared<Observed<int>>(&eventContext);
+        std::shared_ptr<Observed<int>> obs = std::make_shared<Observed<int>>(CustomEventContextFlag, &eventContext);
 
         int calledWith = 77;
         listen(eventContext, obs, [&calledWith](int const& value) -> bool {
@@ -217,7 +217,7 @@ namespace Nui::Tests
     {
         EventContext eventContext;
 
-        std::shared_ptr<Observed<int>> obs = std::make_shared<Observed<int>>(&eventContext);
+        std::shared_ptr<Observed<int>> obs = std::make_shared<Observed<int>>(CustomEventContextFlag, &eventContext);
 
         int calledWith = 77;
         listen(eventContext, obs, [&calledWith](int const& value) -> bool {
@@ -254,7 +254,7 @@ namespace Nui::Tests
     {
         EventContext eventContext;
 
-        Observed<int> obs{&eventContext};
+        Observed<int> obs{CustomEventContextFlag, &eventContext};
 
         int calledWith = 77;
         listen(eventContext, obs, [&calledWith](int const& value) -> bool {


### PR DESCRIPTION
This avoids accidentally using the EventContext* constructor.