### PR TITLE
Fixed scope exit class.

### DIFF
--- a/nui/src/nui/backend/environment_variables_win.cpp
+++ b/nui/src/nui/backend/environment_variables_win.cpp
@@ -12,7 +12,7 @@ namespace Nui
         auto* envStrings = GetEnvironmentStrings();
         if (envStrings == nullptr)
             return {};
-        auto remover = ScopeExit{[&envStrings]() {
+        auto remover = ScopeExit{[&envStrings]() noexcept {
             FreeEnvironmentStrings(envStrings);
         }};
         // var1=value1\0var2=value2\0\0

--- a/nui/src/nui/backend/mac_webview_config_from_window_options.ipp
+++ b/nui/src/nui/backend/mac_webview_config_from_window_options.ipp
@@ -158,8 +158,6 @@ namespace Nui::MacOs
 
     id wkWebViewConfigurationFromOptions(HostNameMappingInfo const* mappingInfo, WindowOptions const& options)
     {
-        std::vector<Nui::ScopeExit<std::function<void()>>> cleaners;
-
         auto const* opts = &options;
         std::optional<WindowOptions> optCopy;
         if (options.folderMappingScheme)

--- a/nui/src/nui/backend/window.cpp
+++ b/nui/src/nui/backend/window.cpp
@@ -461,8 +461,8 @@ namespace Nui
             }
             if (msg.message == WM_APP)
             {
-                auto f = reinterpret_cast<std::function<void()>*>(msg.lParam);
-                ScopeExit se{[f]() {
+                auto* f = reinterpret_cast<std::function<void()>*>(msg.lParam);
+                ScopeExit se{[f]() noexcept {
                     // yuck! but this is from webview internals
                     delete f;
                 }};
@@ -679,7 +679,7 @@ namespace Nui
 
         if (wv23 == nullptr)
             throw std::runtime_error("Could not get interface to set mapping.");
-        auto releaseInterface = Nui::ScopeExit{[wv23] {
+        auto releaseInterface = Nui::ScopeExit{[wv23]() noexcept {
             wv23->Release();
         }};
 

--- a/nui/src/nui/backend/window_impl_linux.ipp
+++ b/nui/src/nui/backend/window_impl_linux.ipp
@@ -57,10 +57,10 @@ extern "C" {
         // const auto scheme = std::string_view{webkit_uri_scheme_request_get_scheme(request)};
         const auto uri = std::string_view{webkit_uri_scheme_request_get_uri(request)};
 
-        auto exitError = Nui::ScopeExit{[&] {
+        auto exitError = Nui::ScopeExit{[&]() noexcept {
             auto* error =
                 g_error_new(WEBKIT_DOWNLOAD_ERROR_DESTINATION, 1, "Invalid custom scheme / Host name mapping.");
-            auto freeError = Nui::ScopeExit{[error] {
+            auto freeError = Nui::ScopeExit{[error]() noexcept {
                 g_error_free(error);
             }};
             webkit_uri_scheme_request_finish_error(request, error);
@@ -84,7 +84,7 @@ extern "C" {
                 auto* stream = webkit_uri_scheme_request_get_http_body(request);
                 if (stream == nullptr)
                     return std::string{};
-                Nui::ScopeExit deleteStream = Nui::ScopeExit{[stream] {
+                Nui::ScopeExit deleteStream = Nui::ScopeExit{[stream]() noexcept {
                     g_input_stream_close(stream, nullptr, nullptr);
                 }};
 
@@ -94,10 +94,10 @@ extern "C" {
                 GError* error = NULL;
                 gchar* data = g_data_input_stream_read_upto(dataInputStream, "", 0, &length, NULL, &error);
 
-                Nui::ScopeExit freeData = Nui::ScopeExit{[data] {
+                Nui::ScopeExit freeData = Nui::ScopeExit{[data]() noexcept {
                     g_free(data);
                 }};
-                Nui::ScopeExit freeError = Nui::ScopeExit{[error] {
+                Nui::ScopeExit freeError = Nui::ScopeExit{[error]() noexcept {
                     g_error_free(error);
                 }};
 


### PR DESCRIPTION
Addressed the following:
- Move assignment posed the question whether a valid onExit should be called or not. This just erases it, because there is no simple definitive answer.
- ScopeExit is no longer a template, the deduction guide was incorrect to get proper forwarding. The template parameter only for the constructor was unnecessary anyways. Moving it to the constructor only.
- Make it explicit that the class expects a noexcept function. It was that way before by the nature of destructors being noexcept, but it is now more explicit about it.

Found by @DNKpp 