### PR TITLE
Cleaned up and improved val conversion.

### DIFF
--- a/nui/include/nui/frontend/utility/val_conversion.hpp
+++ b/nui/include/nui/frontend/utility/val_conversion.hpp
@@ -17,6 +17,7 @@
 #include <filesystem>
 #include <utility>
 #include <unordered_map>
+#include <string_view>
 #include <memory>
 #include <map>
 #include <variant>
@@ -31,85 +32,376 @@ namespace Nui
         template <typename T>
         struct IsOptional<std::optional<T>> : std::true_type
         {};
+
+        /**
+         * @brief Concept detecting if a to_val function is provided for a type.
+         *
+         * @tparam T The type to check for
+         */
+        template <typename T>
+        concept HasToVal = requires(T const& t, Nui::val& v) { to_val(v, t); };
+
+        /**
+         * @brief Concept detecting if a from_val function is provided for a type.
+         *
+         * @tparam T The type to check for
+         */
+        template <typename T>
+        concept HasFromVal = requires(Nui::val const& v, T& t) { from_val(v, t); };
     }
 
+    /**
+     * @brief Converts a boost described class/struct to a Nui::val object.
+     *
+     * @tparam T The class type
+     * @tparam Bases Boost describe bases
+     * @tparam Members Boost describe members
+     * @tparam Enable Used to disable unions for this function
+     * @param obj The object to convert
+     * @return Returns the val.
+     */
     template <
         typename T,
         class Bases = boost::describe::describe_bases<T, boost::describe::mod_any_access>,
         class Members = boost::describe::describe_members<T, boost::describe::mod_any_access>,
-        class Enable = std::enable_if_t<!std::is_union<T>::value>>
-    void convertToVal(Nui::val& val, T const& obj);
+        class Enable = std::enable_if_t<!std::is_union_v<T>>>
+    Nui::val convertToVal(T const& obj);
+
+    /**
+     * @brief Converts an optional<T> to a Nui::val
+     *
+     * @tparam T The wrapped type of the optional
+     * @param option The optional value to convert
+     * @return Nui::val The converted val
+     */
     template <typename T>
     Nui::val convertToVal(std::optional<T> const& option);
+
+    /**
+     * @brief Converts fundamental types to Nui::val
+     *
+     * @tparam T The fundamental type
+     * @param value The value to convert
+     * @return Nui::val The converted val
+     */
     template <typename T>
     requires Fundamental<T>
     Nui::val convertToVal(T const& value);
+
+    /**
+     * @brief Converts string to Nui::val.
+     *
+     * @param value The string to convert.
+     * @return Nui::val The converted val.
+     */
     Nui::val convertToVal(std::string const& value);
+
+    /**
+     * @brief Converts a filesystem path to Nui::val.
+     *
+     * @param value The filesystem path to convert.
+     * @return Nui::val The converted val.
+     */
     Nui::val convertToVal(std::filesystem::path const& value);
+
+    /**
+     * @brief Copy for val. Useful if a class itself contains a val.
+     *
+     * @param value The val to copy.
+     * @return Nui::val The copied val.
+     */
     Nui::val convertToVal(Nui::val value);
+
+    /**
+     * @brief Converts a C-style string to Nui::val.
+     *
+     * @param value The C-style string to convert.
+     * @return Nui::val The converted val.
+     */
     Nui::val convertToVal(char const* value);
+
+    /**
+     * @brief Converts a string_view to Nui::val.
+     *
+     * @param view The string_view to convert.
+     * @return Nui::val The converted val.
+     */
+    Nui::val convertToVal(std::string_view view);
+
+    /**
+     * @brief Converts a vector to Nui::val.
+     *
+     * @tparam T The element type of the vector.
+     * @param vector The vector to convert.
+     * @return Nui::val The converted val.
+     */
     template <typename T>
     Nui::val convertToVal(std::vector<T> const& vector);
+
+    /**
+     * @brief Converts an Observed<T> to Nui::val.
+     *
+     * @tparam T The type of the observed value.
+     * @param observed The observed value to convert.
+     * @return Nui::val The converted val.
+     */
     template <typename T>
     Nui::val convertToVal(Observed<T> const& observed);
+
+    /**
+     * @brief Converts an unordered_map to Nui::val.
+     *
+     * @tparam T The value type of the map.
+     * @param map The map to convert.
+     * @return Nui::val The converted val.
+     */
     template <typename T>
     Nui::val convertToVal(std::unordered_map<std::string, T> const& map);
+
+    /**
+     * @brief Converts a map to Nui::val.
+     *
+     * @tparam T The value type of the map.
+     * @param map The map to convert.
+     * @return Nui::val The converted val.
+     */
     template <typename T>
     Nui::val convertToVal(std::map<std::string, T> const& map);
+
+    /**
+     * @brief Converts a unique pointer to Nui::val.
+     *
+     * @tparam T The type of the pointed-to object.
+     * @param ptr The unique pointer to convert.
+     * @return Nui::val The converted val.
+     */
     template <typename T>
     Nui::val convertToVal(std::unique_ptr<T> const& ptr);
+
+    /**
+     * @brief Converts a shared pointer to Nui::val.
+     *
+     * @tparam T The type of the pointed-to object.
+     * @param ptr The shared pointer to convert.
+     * @return Nui::val The converted val.
+     */
     template <typename T>
     Nui::val convertToVal(std::shared_ptr<T> const& ptr);
+
+    /**
+     * @brief Converts anything that a "to_val" function is provided for found by ADL.
+     *
+     * @tparam T The type of the object.
+     * @param obj The object to convert.
+     * @return Nui::val The converted val.
+     */
+    template <typename T>
+    requires Detail::HasToVal<T>
+    Nui::val convertToVal(T const& value);
+
+#if __POINTER_WIDTH__ == 64
+    /**
+     * @brief Converts a long long to Nui::val. This is only possible when 64bit WASM is enabled.
+     *
+     * @param value The long long to convert.
+     * @return Nui::val The converted val.
+     */
+    Nui::val convertToVal(long long value);
+
+    /**
+     * @brief Converts an unsigned long long to Nui::val. This is only possible when 64bit WASM is enabled.
+     *
+     * @param value The unsigned long long to convert.
+     * @return Nui::val The converted val.
+     */
+    Nui::val convertToVal(unsigned long long value);
+#else
     inline Nui::val convertToVal(long long)
     {
-        throw std::runtime_error("Cannot convert long long to val");
+        throw std::runtime_error("Use -sMEMORY64 to convert long long to val");
     }
+    inline Nui::val convertToVal(unsigned long long)
+    {
+        throw std::runtime_error("Use -sMEMORY64 to convert unsigned long long to val");
+    }
+#endif
+    /**
+     * @brief Converts a monostate to Nui::val (interpreted as undefined)
+     *
+     * @return Nui::val javascript undefined value.
+     */
     inline Nui::val convertToVal(std::monostate)
     {
         return Nui::val::undefined();
     }
+
+    /**
+     * @brief Converts a variant to Nui::val by converting the currently held type.
+     *
+     * @tparam Ts
+     * @param variant
+     * @return Nui::val
+     */
     template <typename... Ts>
     Nui::val convertToVal(std::variant<Ts...> const& variant);
 
-    template <typename T, class Members>
-    requires(!std::is_union_v<T>)
-    void convertFromValObjImpl(Nui::val const& val, T& obj);
+    namespace Detail
+    {
+        template <typename T, class Members>
+        requires(!std::is_union_v<T>)
+        void convertFromValObjImpl(Nui::val const& val, T& obj);
+    }
 
+    /**
+     * @brief Converts a Nui::val to a class/struct object.
+     *
+     * @tparam T The type of the object.
+     * @tparam Bases The base classes of the object.
+     * @tparam Members The members of the object.
+     */
     template <typename T, class Bases, class Members>
     requires(!std::is_union_v<T>)
     void convertFromVal(Nui::val const& val, T& obj);
 
+    /**
+     * @brief Converts a Nui::val to a class/struct object.
+     *
+     * @tparam T The type of the object.
+     * @tparam Members The boost describe members of the object.
+     */
     template <typename T, class Members>
     requires(!std::is_union_v<T> && !boost::describe::has_describe_bases<T>::value)
     void convertFromVal(Nui::val const& val, T& obj);
 
+    /**
+     * @brief Converts a Nui::val to a fundamental type.
+     *
+     * @tparam T The fundamental type.
+     * @param val The val to convert.
+     * @param value The variable to store the converted value.
+     */
     template <typename T>
     requires Fundamental<T>
     void convertFromVal(Nui::val const& val, T& value);
+
+    /**
+     * @brief Converts a Nui::val to a std::string.
+     *
+     * @param val The val to convert.
+     * @param str The variable to store the converted value.
+     */
     void convertFromVal(Nui::val const& val, std::string& str);
+
+    /**
+     * @brief Converts a Nui::val to a std::optional.
+     *
+     * @tparam T The wrapped type of the optional.
+     * @param val The val to convert.
+     * @param option The variable to store the converted value.
+     */
     template <typename T>
     void convertFromVal(Nui::val const& val, std::optional<T>& option);
+
+    /**
+     * @brief Converts a Nui::val to a std::filesystem::path.
+     *
+     * @param val The val to convert.
+     * @param value The variable to store the converted value.
+     */
     void convertFromVal(Nui::val const& val, std::filesystem::path& value);
+
+    /**
+     * @brief Converts a Nui::val to a Nui::val (copy).
+     *
+     * @param val The val to convert.
+     * @param value The variable to store the converted value.
+     */
     void convertFromVal(Nui::val const& val, Nui::val& value);
+
+    /**
+     * @brief Converts a Nui::val to a std::vector.
+     *
+     * @tparam T The type of the vector elements.
+     * @param val The val to convert.
+     * @param vector The variable to store the converted value.
+     */
     template <typename T>
     void convertFromVal(Nui::val const& val, std::vector<T>& vector);
+
+    /**
+     * @brief Converts a Nui::val to a std::vector of fundamentals.
+     *
+     * @tparam T The type of the vector elements.
+     * @param val The val to convert.
+     * @param vector The variable to store the converted value.
+     */
     template <typename T>
     requires Fundamental<T>
     void convertFromVal(Nui::val const& val, std::vector<T>& vector);
+
+    /**
+     * @brief Converts a Nui::val to an Observed<T>.
+     *
+     * @tparam T The type of the observed value.
+     * @param val The val to convert.
+     * @param observed The variable to store the converted value.
+     */
     template <typename T>
     void convertFromVal(Nui::val const& val, Observed<T>& observed);
+
+    /**
+     * @brief Converts a Nui::val to a std::unordered_map.
+     *
+     * @tparam T The type of the map values.
+     * @param val The val to convert.
+     * @param map The variable to store the converted value.
+     */
     template <typename T>
     void convertFromVal(Nui::val const& val, std::unordered_map<std::string, T>& map);
+
+    /**
+     * @brief Converts a Nui::val to a type that has a "from_val" function provided found by ADL.
+     *
+     * @tparam T The type of the value.
+     * @param val The val to convert.
+     * @param value The variable to store the converted value.
+     */
+    template <typename T>
+    requires Detail::HasFromVal<T>
+    void convertFromVal(Nui::val const& val, T& value);
+
+#if __POINTER_WIDTH__ == 64
+    /**
+     * @brief Converts a Nui::val to a long long. This is only possible when 64bit WASM is enabled.
+     *
+     * @param val The val to convert.
+     * @param value The variable to store the converted value.
+     */
+    void convertFromVal(Nui::val const& val, long long& value);
+
+    /**
+     * @brief Converts a Nui::val to an unsigned long long. This is only possible when 64bit WASM is enabled.
+     *
+     * @param val The val to convert.
+     * @param value The variable to store the converted value.
+     */
+    void convertFromVal(Nui::val const& val, unsigned long long& value);
+#else
     inline void convertFromVal(Nui::val const&, long long)
     {
-        throw std::invalid_argument("Cannot convert from val to long long");
+        throw std::invalid_argument("Use -sMEMORY64 to convert from val to long long");
     }
 
-    template <typename T, class Bases, class Members, class Enable>
-    void convertToVal(Nui::val& val, T const& obj)
+    inline void convertFromVal(Nui::val const& val, unsigned long long& value)
     {
-        if (val.typeOf().as<std::string>() != "object")
-            val = Nui::val::object();
+        throw std::invalid_argument("Use -sMEMORY64 to convert from val to unsigned long long");
+    }
+#endif
+
+    template <typename T, class Bases, class Members, class Enable>
+    Nui::val convertToVal(T const& obj)
+    {
+        Nui::val val = Nui::val::object();
 
         boost::mp11::mp_for_each<Bases>([&](auto&& base) {
             using type = typename std::decay_t<decltype(base)>::type;
@@ -119,16 +411,7 @@ namespace Nui
         boost::mp11::mp_for_each<Members>([&](auto&& memAccessor) {
             val.set(memAccessor.name, convertToVal(obj.*memAccessor.pointer));
         });
-    }
-    template <
-        typename T,
-        class Bases = boost::describe::describe_bases<T, boost::describe::mod_any_access>,
-        class Members = boost::describe::describe_members<T, boost::describe::mod_any_access>,
-        class Enable = std::enable_if_t<!std::is_union<T>::value>>
-    Nui::val convertToVal(T const& obj)
-    {
-        Nui::val val = Nui::val::object();
-        convertToVal(val, obj);
+
         return val;
     }
 
@@ -146,6 +429,10 @@ namespace Nui
     inline Nui::val convertToVal(std::string const& value)
     {
         return Nui::val{value};
+    }
+    inline Nui::val convertToVal(std::string_view value)
+    {
+        return convertToVal(std::string{value});
     }
     inline Nui::val convertToVal(std::filesystem::path const& value)
     {
@@ -193,16 +480,14 @@ namespace Nui
     {
         if (ptr)
             return convertToVal(*ptr);
-        else
-            return Nui::val::null();
+        return Nui::val::null();
     }
     template <typename T>
     Nui::val convertToVal(std::shared_ptr<T> const& ptr)
     {
         if (ptr)
             return convertToVal(*ptr);
-        else
-            return Nui::val::null();
+        return Nui::val::null();
     }
     template <typename... Ts>
     Nui::val convertToVal(std::variant<Ts...> const& variant)
@@ -214,11 +499,31 @@ namespace Nui
             variant);
     }
 
+    template <typename T>
+    requires Detail::HasToVal<T>
+    Nui::val convertToVal(T const& value)
+    {
+        Nui::val val;
+        to_val(val, value);
+        return val;
+    }
+
+#if __POINTER_WIDTH__ == 64
+    inline Nui::val convertToVal(long long value)
+    {
+        return Nui::val{value};
+    }
+    inline Nui::val convertToVal(unsigned long long value)
+    {
+        return Nui::val{value};
+    }
+#endif
+
     template <typename T, class Members = boost::describe::describe_members<T, boost::describe::mod_any_access>>
     requires(!std::is_union_v<T> && !boost::describe::has_describe_bases<T>::value)
     void convertFromVal(Nui::val const& val, T& obj)
     {
-        convertFromValObjImpl<T, Members>(val, obj);
+        Detail::convertFromValObjImpl<T, Members>(val, obj);
     }
 
     template <
@@ -232,29 +537,44 @@ namespace Nui
             using type = typename std::decay_t<decltype(base)>::type;
             convertFromVal(val, static_cast<type&>(obj));
         });
-        convertFromValObjImpl<T, Members>(val, obj);
+        Detail::convertFromValObjImpl<T, Members>(val, obj);
     }
 
-    template <typename T, class Members = boost::describe::describe_members<T, boost::describe::mod_any_access>>
-    requires(!std::is_union_v<T>)
-    void convertFromValObjImpl(Nui::val const& val, T& obj)
+    namespace Detail
     {
-        boost::mp11::mp_for_each<Members>([&](auto&& memAccessor) {
-            if (val.hasOwnProperty(memAccessor.name))
-            {
-                if constexpr (!Detail::IsOptional<decltype(obj.*memAccessor.pointer)>::value)
+        template <typename T, class Members = boost::describe::describe_members<T, boost::describe::mod_any_access>>
+        requires(!std::is_union_v<T>)
+        void convertFromValObjImpl(Nui::val const& val, T& obj)
+        {
+            boost::mp11::mp_for_each<Members>([&](auto&& memAccessor) {
+                if (val.hasOwnProperty(memAccessor.name))
                 {
-                    if (val[memAccessor.name].isNull() || val[memAccessor.name].isUndefined())
-                        Nui::val::global("console").call<void>(
-                            "error",
-                            std::string{"Expected member "} + memAccessor.name + " to be defined and non null");
+                    if constexpr (!Detail::IsOptional<decltype(obj.*memAccessor.pointer)>::value)
+                    {
+                        if (val[memAccessor.name].isNull() || val[memAccessor.name].isUndefined())
+                        {
+                            throw std::invalid_argument(
+                                std::string{"Expected member "} + memAccessor.name + " to be non nullish");
+                        }
+                        convertFromVal(val[memAccessor.name], obj.*memAccessor.pointer);
+                    }
                     else
                         convertFromVal(val[memAccessor.name], obj.*memAccessor.pointer);
                 }
                 else
-                    convertFromVal(val[memAccessor.name], obj.*memAccessor.pointer);
-            }
-        });
+                {
+                    if constexpr (Detail::IsOptional<decltype(obj.*memAccessor.pointer)>::value)
+                    {
+                        // If the member is optional and not present, set to nullopt:
+                        obj.*memAccessor.pointer = std::nullopt;
+                    }
+                    else
+                    {
+                        throw std::invalid_argument(std::string{"Missing required member "} + memAccessor.name);
+                    }
+                }
+            });
+        }
     }
 
     template <typename T>
@@ -326,4 +646,22 @@ namespace Nui
             map.emplace(key, std::move(value));
         }
     }
+
+    template <typename T>
+    requires Detail::HasFromVal<T>
+    void convertFromVal(Nui::val const& val, T& value)
+    {
+        from_val(val, value);
+    }
+
+#if __POINTER_WIDTH__ == 64
+    inline void convertFromVal(Nui::val const& val, long long& value)
+    {
+        value = val.as<long long>();
+    }
+    inline void convertFromVal(Nui::val const& val, unsigned long long& value)
+    {
+        value = val.as<unsigned long long>();
+    }
+#endif
 }


### PR DESCRIPTION
- Added doxygen comments
- Added string_view "convertToVal"
- Allow providing to_val and from_val functions analogous to to_json and from_json how nlohmann json does it.
- Allow long long types to be converted if MEMORY64 is supplied to emscripten.
- converting from a val to a boost described object:
  - When the member is missing, its no longer ignored, but throws if its not an optional.
  - null/undefined for non optionals no longer print to the console but throw an exception.