### PR TITLE
Add decay to combinator and cleaned up attribute factories.

### DIFF
--- a/nui/include/nui/event_system/observed_value_combinator.hpp
+++ b/nui/include/nui/event_system/observed_value_combinator.hpp
@@ -107,6 +107,8 @@ namespace Nui
     class ObservedValueCombinatorWithGenerator : public ObservedValueCombinatorBase<ObservedValues...>
     {
       public:
+        using RendererTypeNoRef = std::decay_t<RendererType>;
+
         constexpr ObservedValueCombinatorWithGenerator(
             std::tuple<Detail::ObservedAddReference_t<ObservedValues>...> observedValues,
             RendererType generator)
@@ -124,17 +126,17 @@ namespace Nui
             return generator_();
         }
 
-        RendererType generator() const&
+        RendererTypeNoRef generator() const&
         {
             return generator_;
         }
-        RendererType generator() &&
+        RendererTypeNoRef generator() &&
         {
             return std::move(generator_);
         }
 
       protected:
-        RendererType generator_;
+        RendererTypeNoRef generator_;
     };
 
     template <typename RendererType, typename... ObservedValues>
@@ -163,19 +165,19 @@ namespace Nui
 
         template <typename RendererType>
         requires std::invocable<RendererType>
-        constexpr ObservedValueCombinatorWithGenerator<RendererType, ObservedValues...>
+        constexpr ObservedValueCombinatorWithGenerator<std::decay_t<RendererType>, ObservedValues...>
         generate(RendererType&& generator)
         {
-            return ObservedValueCombinatorWithGenerator<RendererType, ObservedValues...>{
+            return ObservedValueCombinatorWithGenerator<std::decay_t<RendererType>, ObservedValues...>{
                 observedValues_, std::forward<RendererType>(generator)};
         }
 
         template <typename RendererType>
         requires std::invocable<RendererType>
-        constexpr ObservedValueCombinatorWithPropertyGenerator<RendererType, ObservedValues...>
+        constexpr ObservedValueCombinatorWithPropertyGenerator<std::decay_t<RendererType>, ObservedValues...>
         generateProperty(RendererType&& generator)
         {
-            return ObservedValueCombinatorWithPropertyGenerator<RendererType, ObservedValues...>{
+            return ObservedValueCombinatorWithPropertyGenerator<std::decay_t<RendererType>, ObservedValues...>{
                 observedValues_, std::forward<RendererType>(generator)};
         }
     };

--- a/nui/include/nui/frontend/attributes/style.hpp
+++ b/nui/include/nui/frontend/attributes/style.hpp
@@ -17,7 +17,6 @@
 #include <tuple>
 #include <string>
 #include <sstream>
-#include <optional>
 
 namespace Nui::Attributes
 {
@@ -167,11 +166,19 @@ namespace Nui::Attributes
     struct StyleProperty
     {
         char const* name;
-        constexpr StyleProperty(char const* name)
+        constexpr explicit StyleProperty(char const* name)
             : name{name}
         {}
+
+        StyleProperty& operator=(StyleProperty const&) = delete;
+        StyleProperty& operator=(StyleProperty&&) noexcept = delete;
+        StyleProperty(StyleProperty const&) = default;
+        StyleProperty(StyleProperty&&) noexcept = default;
+        ~StyleProperty() = default;
+
         // TODO: optimize following functions:
-        auto operator=(char const* value)
+        // NOLINTNEXTLINE(misc-unconventional-assign-operator, cppcoreguidelines-c-copy-assignment-signature)
+        auto operator=(char const* value) const
         {
             return StylePropertyImpl{
                 [name_ = std::string{name}, value = std::string{value}]() {
@@ -179,7 +186,8 @@ namespace Nui::Attributes
                 },
                 nullptr};
         }
-        auto operator=(std::string value)
+        // NOLINTNEXTLINE(misc-unconventional-assign-operator, cppcoreguidelines-c-copy-assignment-signature)
+        auto operator=(std::string value) const
         {
             return StylePropertyImpl{
                 [name_ = std::string{name}, value = std::move(value)]() {
@@ -187,7 +195,8 @@ namespace Nui::Attributes
                 },
                 nullptr};
         }
-        auto operator=(Observed<std::string> const& observedValue)
+        // NOLINTNEXTLINE(misc-unconventional-assign-operator, cppcoreguidelines-c-copy-assignment-signature)
+        auto operator=(Observed<std::string> const& observedValue) const
         {
             return StylePropertyImpl{
                 [name_ = std::string{name}, &observedValue]() {
@@ -195,7 +204,8 @@ namespace Nui::Attributes
                 },
                 observedValue};
         }
-        auto operator=(std::weak_ptr<Observed<std::string>>&& observedValue)
+        // NOLINTNEXTLINE(misc-unconventional-assign-operator, cppcoreguidelines-c-copy-assignment-signature)
+        auto operator=(std::weak_ptr<Observed<std::string>>&& observedValue) const
         {
             return StylePropertyImpl{
                 [name_ = std::string{name}, observedValue = std::weak_ptr{observedValue.lock()}]() {
@@ -205,7 +215,8 @@ namespace Nui::Attributes
                 },
                 std::move(observedValue)};
         }
-        auto operator=(std::shared_ptr<Observed<std::string>> observedValue)
+        // NOLINTNEXTLINE(misc-unconventional-assign-operator, cppcoreguidelines-c-copy-assignment-signature)
+        auto operator=(std::shared_ptr<Observed<std::string>> observedValue) const
         {
             return StylePropertyImpl{
                 [name_ = std::string{name}, observedValue = std::weak_ptr{observedValue}]() {
@@ -216,7 +227,8 @@ namespace Nui::Attributes
                 std::move(observedValue)};
         }
         template <typename FunctionT, typename... ArgsT>
-        auto operator=(ObservedValueCombinatorWithGenerator<FunctionT, ArgsT...>&& combinator)
+        // NOLINTNEXTLINE(misc-unconventional-assign-operator, cppcoreguidelines-c-copy-assignment-signature)
+        auto operator=(ObservedValueCombinatorWithGenerator<FunctionT, ArgsT...>&& combinator) const
         {
             return StylePropertyImpl{
                 [name_ = std::string{name}, gen = combinator.generator()]() {
@@ -243,6 +255,7 @@ namespace Nui::Attributes
                 // TODO: better performing version:
                 std::stringstream sstr;
                 [&sstr](auto const& head, auto const&... tail) {
+                    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
                     using expander = int[];
                     const auto headStr = head();
                     sstr << headStr;
@@ -273,7 +286,7 @@ namespace Nui::Attributes
             Nui::Detail::TupleFilter_t<Detail::IsDynamicStyleProperty, Properties...>,
             Detail::StripPropertyObserved>;
 
-        constexpr Style(Properties&&... props)
+        constexpr explicit Style(Properties&&... props)
             : observedValues_{stripObserved(props...)}
             , generateStyle_{makeStyleGenerator<isStatic()>(std::forward<Properties>(props)...)}
         {}
@@ -305,19 +318,29 @@ namespace Nui::Attributes
 
     struct style_
     {
+        style_& operator=(style_&&) noexcept = delete;
+        style_& operator=(style_ const&) = delete;
+        style_() = default;
+        style_(style_&&) noexcept = default;
+        style_(style_ const&) = default;
+        ~style_() = default;
+
         template <typename U>
         requires(!IsObserved<std::decay_t<U>>)
+        // NOLINTNEXTLINE(misc-unconventional-assign-operator, cppcoreguidelines-c-copy-assignment-signature)
         Attribute operator=(U&& val) const
         {
             return AttributeFactory{"style"}.operator=(std::forward<U>(val));
         }
         template <typename U>
         requires(IsObserved<std::decay_t<U>>)
+        // NOLINTNEXTLINE(misc-unconventional-assign-operator, cppcoreguidelines-c-copy-assignment-signature)
         Attribute operator=(U& val) const
         {
             return AttributeFactory{"style"}.operator=(val);
         }
         template <typename... T>
+        // NOLINTNEXTLINE(misc-unconventional-assign-operator, cppcoreguidelines-c-copy-assignment-signature)
         auto operator=(Style<T...>&& style) const
         {
             if constexpr (Style<T...>::isStatic())

--- a/nui/test/nui/test_attributes.hpp
+++ b/nui/test/nui/test_attributes.hpp
@@ -764,4 +764,20 @@ namespace Nui::Tests
         other = false;
         EXPECT_NO_FATAL_FAILURE(globalEventContext.executeActiveEventsImmediately());
     }
+
+    TEST_F(TestAttributes, CanUseLvalueLambdaForGenerate)
+    {
+        using Nui::Elements::body;
+        using Nui::Attributes::class_;
+
+        auto lambda = [this]() -> std::string {
+            (void)this;
+            return "Hello";
+        };
+        Observed<bool> bla{true};
+
+        render(body{class_ = observe(bla).generate(lambda)}());
+
+        EXPECT_EQ(Nui::val::global("document")["body"]["attributes"]["class"].as<std::string>(), "Hello");
+    }
 }

--- a/nui/test/nui/test_render.hpp
+++ b/nui/test/nui/test_render.hpp
@@ -299,9 +299,10 @@ namespace Nui::Tests
     {
         using Nui::Elements::div;
 
-        render(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(
-            div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(
-                div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}())))))))))))))))))))))))))))))))))))))))))));
+        render(
+            div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(
+                div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(
+                    div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}(div{}())))))))))))))))))))))))))))))))))))))))))));
     }
 
     TEST_F(TestRender, StableElementIsNotRerendered)
@@ -759,18 +760,19 @@ namespace Nui::Tests
 
         Nui::Observed<std::vector<std::string>> range{std::vector<std::string>{"A", "B", "C", "D"}};
 
-        render(body{
-            class_ = "range-parent",
-        }(range.map([](long long, auto const& element) {
-            return div{
-                class_ = "range-child",
-                id = element,
-            }([]() -> Nui::ElementRenderer {
-                return span{
-                    class_ = "range-child-child",
-                }();
-            });
-        })));
+        render(
+            body{
+                class_ = "range-parent",
+            }(range.map([](long long, auto const& element) {
+                return div{
+                    class_ = "range-child",
+                    id = element,
+                }([]() -> Nui::ElementRenderer {
+                    return span{
+                        class_ = "range-child-child",
+                    }();
+                });
+            })));
 
         auto children = Nui::val::global("document")["body"]["children"].as<Nui::Tests::Engine::Array>();
         ASSERT_EQ(children.size(), range.value().size());
@@ -900,5 +902,18 @@ namespace Nui::Tests
         globalEventContext.executeActiveEventsImmediately();
 
         EXPECT_EQ(nested["textContent"].as<std::string>(), "Goodbye");
+    }
+
+    TEST_F(TestRender, CanUseLvalueLambdaForGenerate)
+    {
+        using Nui::Elements::body;
+
+        auto lambda = [this]() -> std::string {
+            (void)this;
+            return "Hello";
+        };
+        Observed<bool> bla{true};
+
+        render(body{}(observe(bla).generate(lambda)));
     }
 }


### PR DESCRIPTION
```c++
auto lam = [](){return "";};
Observed<T> x{};

body{
}(
  observe(x).generate(lam)
})
```
Did not build prior to this fix.