### PR TITLE
Fixed missing decay in convertFromVal optional check.

### DIFF
--- a/nui/include/nui/frontend/utility/val_conversion.hpp
+++ b/nui/include/nui/frontend/utility/val_conversion.hpp
@@ -126,7 +126,7 @@ namespace Nui
      * @param view The string_view to convert.
      * @return Nui::val The converted val.
      */
-    Nui::val convertToVal(std::string_view view);
+    Nui::val convertToVal(std::string_view value);
 
     /**
      * @brief Converts a vector to Nui::val.
@@ -549,7 +549,7 @@ namespace Nui
             boost::mp11::mp_for_each<Members>([&](auto&& memAccessor) {
                 if (val.hasOwnProperty(memAccessor.name))
                 {
-                    if constexpr (!Detail::IsOptional<decltype(obj.*memAccessor.pointer)>::value)
+                    if constexpr (!Detail::IsOptional<std::decay_t<decltype(obj.*memAccessor.pointer)>>::value)
                     {
                         if (val[memAccessor.name].isNull() || val[memAccessor.name].isUndefined())
                         {
@@ -563,7 +563,7 @@ namespace Nui
                 }
                 else
                 {
-                    if constexpr (Detail::IsOptional<decltype(obj.*memAccessor.pointer)>::value)
+                    if constexpr (Detail::IsOptional<std::decay_t<decltype(obj.*memAccessor.pointer)>>::value)
                     {
                         // If the member is optional and not present, set to nullopt:
                         obj.*memAccessor.pointer = std::nullopt;


### PR DESCRIPTION
The following behaved incorrectly:
```c++
struct A {
  std::optional<int> foo{std::nullopt};
};
BOOST_DESCRIBE_STRUCT(A, (), (foo))

Nui::val val = Nui::val::object();
A a{};
Nui::convertFromVal(val, a); // exception: Missing field foo
```
Exception should not be thrown.