### PR TITLE
Fix multi ranges

### DIFF
--- a/cmake/dependencies/interval_tree.cmake
+++ b/cmake/dependencies/interval_tree.cmake
@@ -1,6 +1,6 @@
 option(NUI_FETCH_INTERVAL_TREE "Fetch interval tree" ON)
 set(NUI_INTERVAL_TREE_GIT_REPOSITORY "https://github.com/5cript/interval-tree.git" CACHE STRING "interval tree git repository")
-set(NUI_INTERVAL_TREE_GIT_TAG "v2.3.2" CACHE STRING "interval tree git tag")
+set(NUI_INTERVAL_TREE_GIT_TAG "v3.1.1" CACHE STRING "interval tree git tag")
 
 if(NUI_FETCH_INTERVAL_TREE)
     include(FetchContent)

--- a/nui/include/nui/event_system/observed_value.hpp
+++ b/nui/include/nui/event_system/observed_value.hpp
@@ -744,47 +744,21 @@ namespace Nui
       public:
         explicit ObservedContainer(CustomEventContextFlag_t, EventContext& ctx)
             : ModifiableObserved<ContainerT, Tags>{CustomEventContextFlag, ctx}
-            , rangeContext_{std::make_shared<RangeEventContext>()}
             , afterEffectId_{registerAfterEffect()}
         {}
         explicit ObservedContainer()
             : ModifiableObserved<ContainerT, Tags>{}
-            , rangeContext_{std::make_shared<RangeEventContext>()}
             , afterEffectId_{registerAfterEffect()}
         {}
         template <typename T = ContainerT>
         explicit ObservedContainer(CustomEventContextFlag_t, EventContext& ctx, T&& t)
             : ModifiableObserved<ContainerT, Tags>{CustomEventContextFlag, ctx, std::forward<T>(t)}
-            , rangeContext_{std::make_shared<RangeEventContext>()}
             , afterEffectId_{registerAfterEffect()}
         {}
         template <typename T = ContainerT>
         requires std::constructible_from<ContainerT, T>
         explicit ObservedContainer(T&& t)
             : ModifiableObserved<ContainerT, Tags>{std::forward<T>(t)}
-            , rangeContext_{std::make_shared<RangeEventContext>()}
-            , afterEffectId_{registerAfterEffect()}
-        {}
-        explicit ObservedContainer(RangeEventContext&& rangeContext)
-            : ModifiableObserved<ContainerT, Tags>{}
-            , rangeContext_{std::make_shared<RangeEventContext>(std::move(rangeContext))}
-            , afterEffectId_{registerAfterEffect()}
-        {}
-        explicit ObservedContainer(CustomEventContextFlag_t, EventContext& ctx, RangeEventContext&& rangeContext)
-            : ModifiableObserved<ContainerT, Tags>{CustomEventContextFlag, ctx}
-            , rangeContext_{std::make_shared<RangeEventContext>(std::move(rangeContext))}
-            , afterEffectId_{registerAfterEffect()}
-        {}
-        template <typename T = ContainerT>
-        ObservedContainer(T&& t, RangeEventContext&& rangeContext)
-            : ModifiableObserved<ContainerT, Tags>{std::forward<T>(t)}
-            , rangeContext_{std::make_shared<RangeEventContext>(std::move(rangeContext))}
-            , afterEffectId_{registerAfterEffect()}
-        {}
-        template <typename T = ContainerT>
-        ObservedContainer(CustomEventContextFlag_t, EventContext& ctx, T&& t, RangeEventContext&& rangeContext)
-            : ModifiableObserved<ContainerT, Tags>{CustomEventContextFlag, ctx, std::forward<T>(t)}
-            , rangeContext_{std::make_shared<RangeEventContext>(std::move(rangeContext))}
             , afterEffectId_{registerAfterEffect()}
         {}
 
@@ -805,7 +779,6 @@ namespace Nui
         ObservedContainer& operator=(T&& t)
         {
             contained_ = std::forward<T>(t);
-            rangeContext_->reset(true);
             forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
             update();
             return *this;
@@ -813,7 +786,6 @@ namespace Nui
         void assign(size_type count, const value_type& value)
         {
             contained_.assign(count, value);
-            rangeContext_->reset(true);
             forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
             update();
         }
@@ -821,14 +793,12 @@ namespace Nui
         void assign(Iterator first, Iterator last)
         {
             contained_.assign(first, last);
-            rangeContext_->reset(true);
             forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
             update();
         }
         void assign(std::initializer_list<value_type> ilist)
         {
             contained_.assign(ilist);
-            rangeContext_->reset(true);
             forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
             update();
         }
@@ -960,7 +930,6 @@ namespace Nui
         void clear()
         {
             contained_.clear();
-            rangeContext_->reset(true);
             forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
             update();
         }
@@ -973,7 +942,6 @@ namespace Nui
             NUI_ASSERT(ObservedBase::eventContext_ != nullptr, "Event context must never be null.");
 
             const auto result = contained_.insert(value);
-            rangeContext_->performFullRangeUpdate();
             forEachReaderContext([](RangeEventContext& c) { c.performFullRangeUpdate(); });
             update();
             ObservedBase::eventContext_->executeActiveEventsImmediately();
@@ -988,7 +956,6 @@ namespace Nui
             NUI_ASSERT(ObservedBase::eventContext_ != nullptr, "Event context must never be null.");
 
             const auto result = contained_.insert(std::move(value));
-            rangeContext_->performFullRangeUpdate();
             forEachReaderContext([](RangeEventContext& c) { c.performFullRangeUpdate(); });
             update();
             ObservedBase::eventContext_->executeActiveEventsImmediately();
@@ -1190,7 +1157,6 @@ namespace Nui
         void swap(ContainerT& other)
         {
             contained_.swap(other);
-            rangeContext_->reset(true);
             forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
             update();
         }
@@ -1204,14 +1170,6 @@ namespace Nui
         {
             return contained_;
         }
-        RangeEventContext& rangeContext()
-        {
-            return *rangeContext_;
-        }
-        RangeEventContext const& rangeContext() const
-        {
-            return *rangeContext_;
-        }
         void attachReaderContext(std::shared_ptr<RangeEventContext> const& ctx) const
         {
             readerContexts_->emplace_back(ctx);
@@ -1221,10 +1179,7 @@ namespace Nui
         void update(bool force = false) const override
         {
             if (force)
-            {
-                rangeContext_->reset(true);
                 forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
-            }
             ObservedBase::eventContext_->activateAfterEffect(afterEffectId_);
             ObservedBase::update(force);
         }
@@ -1255,14 +1210,25 @@ namespace Nui
             doInsert = [&](int retries) {
                 NUI_ASSERT(ObservedBase::eventContext_ != nullptr, "Event context must never be null.");
 
-                const auto result = rangeContext_->insertModificationRange(low, high, type);
-                forEachReaderContext([&](RangeEventContext& c) { c.insertModificationRange(low, high, type); });
-                if (result == RangeEventContext::InsertResult::Perform)
+                bool needsRetry = false;
+                bool needsFlush = false;
+                bool rejected = false;
+                forEachReaderContext([&](RangeEventContext& c) {
+                    auto const r = c.insertModificationRange(low, high, type);
+                    if (r == RangeEventContext::InsertResult::Perform)
+                        needsFlush = true;
+                    else if (r == RangeEventContext::InsertResult::PerformAndRetry)
+                        needsRetry = true;
+                    else if (r == RangeEventContext::InsertResult::Rejected)
+                        rejected = true;
+                });
+
+                if (needsFlush && !needsRetry)
                 {
                     update();
                     ObservedBase::eventContext_->executeActiveEventsImmediately();
                 }
-                else if (result == RangeEventContext::InsertResult::PerformAndRetry)
+                else if (needsRetry)
                 {
                     update();
                     ObservedBase::eventContext_->executeActiveEventsImmediately();
@@ -1271,25 +1237,23 @@ namespace Nui
                         doInsert(retries + 1);
                     else
                     {
-                        rangeContext_->reset(true);
                         forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
                         update();
                         ObservedBase::eventContext_->executeActiveEventsImmediately();
                         return;
                     }
                 }
-                else if (result == RangeEventContext::InsertResult::Accepted)
+                else if (rejected)
                 {
-                    update();
-                }
-                else
-                {
-                    // Rejected! (why?)
-                    rangeContext_->reset(true);
                     forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
                     update();
                     ObservedBase::eventContext_->executeActiveEventsImmediately();
                     return;
+                }
+                else
+                {
+                    // all Accepted (or no readers)
+                    update();
                 }
             };
 
@@ -1300,20 +1264,15 @@ namespace Nui
         {
             NUI_ASSERT(ObservedBase::eventContext_ != nullptr, "Event context must never be null.");
             return ObservedBase::eventContext_->registerAfterEffect(
-                Event{[weak = std::weak_ptr<RangeEventContext>{rangeContext_},
-                       weakReaders = std::weak_ptr<std::vector<std::weak_ptr<RangeEventContext>>>{
-                           readerContexts_}](EventContext::EventIdType) {
-                    auto shared = weak.lock();
-                    if (!shared)
+                Event{[weakReaders = std::weak_ptr<std::vector<std::weak_ptr<RangeEventContext>>>{
+                          readerContexts_}](EventContext::EventIdType) {
+                    auto sharedReaders = weakReaders.lock();
+                    if (!sharedReaders)
                         return false;
-                    shared->reset();
-                    if (auto sharedReaders = weakReaders.lock())
+                    for (auto& w : *sharedReaders)
                     {
-                        for (auto& w : *sharedReaders)
-                        {
-                            if (auto r = w.lock())
-                                r->reset();
-                        }
+                        if (auto r = w.lock())
+                            r->reset();
                     }
                     return true;
                 }});
@@ -1321,9 +1280,12 @@ namespace Nui
 
         void eraseNotify(std::size_t index, std::size_t high)
         {
-            const bool fixupPerformed = rangeContext_->eraseNotify(index, high);
-            forEachReaderContext([&](RangeEventContext& c) { c.eraseNotify(index, high); });
-            if (fixupPerformed) // FORCE update:
+            bool anyFixup = false;
+            forEachReaderContext([&](RangeEventContext& c) {
+                if (c.eraseNotify(index, high))
+                    anyFixup = true;
+            });
+            if (anyFixup) // FORCE update:
             {
                 update();
                 ObservedBase::eventContext_->executeActiveEventsImmediately();
@@ -1332,7 +1294,6 @@ namespace Nui
 
       protected:
         MoveDetector moveDetector_;
-        mutable std::shared_ptr<RangeEventContext> rangeContext_;
         mutable std::shared_ptr<std::vector<std::weak_ptr<RangeEventContext>>> readerContexts_{
             std::make_shared<std::vector<std::weak_ptr<RangeEventContext>>>()};
         mutable EventContext::EventIdType afterEffectId_;
@@ -1445,15 +1406,11 @@ namespace Nui
         using ObservedContainer<std::set<Parameters...>, Tags>::operator->;
         using observed_type = std::set<Parameters...>;
 
-      public:
-        Observed()
-            : ObservedContainer<std::set<Parameters...>, Tags>{RangeEventContext{true}}
-        {}
-        template <typename T = std::set<Parameters...>>
-        requires std::constructible_from<std::set<Parameters...>, T>
-        explicit Observed(T&& t)
-            : ObservedContainer<std::set<Parameters...>, Tags>{std::forward<T>(t), RangeEventContext{true}}
-        {}
+        void attachReaderContext(std::shared_ptr<RangeEventContext> const& ctx) const
+        {
+            ObservedContainer<std::set<Parameters...>, Tags>::attachReaderContext(ctx);
+            ctx->setDisableOptimizations(true);
+        }
 
         Observed<std::set<Parameters...>, Tags>& operator=(std::set<Parameters...> const& contained)
         {
@@ -1476,15 +1433,11 @@ namespace Nui
         using ObservedContainer<std::list<Parameters...>, Tags>::operator->;
         using observed_type = std::list<Parameters...>;
 
-      public:
-        Observed()
-            : ObservedContainer<std::list<Parameters...>, Tags>{RangeEventContext{true}}
-        {}
-        template <typename T = std::list<Parameters...>>
-        requires std::constructible_from<std::list<Parameters...>, T>
-        explicit Observed(T&& t)
-            : ObservedContainer<std::list<Parameters...>, Tags>{std::forward<T>(t), RangeEventContext{true}}
-        {}
+        void attachReaderContext(std::shared_ptr<RangeEventContext> const& ctx) const
+        {
+            ObservedContainer<std::list<Parameters...>, Tags>::attachReaderContext(ctx);
+            ctx->setDisableOptimizations(true);
+        }
 
         Observed<std::list<Parameters...>, Tags>& operator=(std::list<Parameters...> const& contained)
         {

--- a/nui/include/nui/event_system/observed_value.hpp
+++ b/nui/include/nui/event_system/observed_value.hpp
@@ -1175,6 +1175,11 @@ namespace Nui
             readerContexts_->emplace_back(ctx);
         }
 
+        std::size_t readerContextCount() const
+        {
+            return readerContexts_->size();
+        }
+
       protected:
         void update(bool force = false) const override
         {

--- a/nui/include/nui/event_system/observed_value.hpp
+++ b/nui/include/nui/event_system/observed_value.hpp
@@ -1204,6 +1204,10 @@ namespace Nui
         {
             return *rangeContext_;
         }
+        void attachReaderContext(std::shared_ptr<RangeEventContext> const& ctx) const
+        {
+            readerContexts_.emplace_back(ctx);
+        }
 
       protected:
         void update(bool force = false) const override
@@ -1215,6 +1219,24 @@ namespace Nui
         }
 
       protected:
+        template <typename Fn>
+        void forEachReaderContext(Fn const& fn) const
+        {
+            auto it = readerContexts_.begin();
+            while (it != readerContexts_.end())
+            {
+                if (auto shared = it->lock())
+                {
+                    fn(*shared);
+                    ++it;
+                }
+                else
+                {
+                    it = readerContexts_.erase(it);
+                }
+            }
+        }
+
         void insertRangeChecked(std::size_t low, std::size_t high, RangeOperationType type)
         {
             std::function<void(int)> doInsert;
@@ -1287,6 +1309,7 @@ namespace Nui
         MoveDetector moveDetector_;
         mutable std::shared_ptr<RangeEventContext> rangeContext_;
         mutable EventContext::EventIdType afterEffectId_;
+        mutable std::vector<std::weak_ptr<RangeEventContext>> readerContexts_;
     };
 
     template <typename T, typename Tags = void>

--- a/nui/include/nui/event_system/observed_value.hpp
+++ b/nui/include/nui/event_system/observed_value.hpp
@@ -806,6 +806,7 @@ namespace Nui
         {
             contained_ = std::forward<T>(t);
             rangeContext_->reset(true);
+            forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
             update();
             return *this;
         }
@@ -813,6 +814,7 @@ namespace Nui
         {
             contained_.assign(count, value);
             rangeContext_->reset(true);
+            forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
             update();
         }
         template <typename Iterator>
@@ -820,12 +822,14 @@ namespace Nui
         {
             contained_.assign(first, last);
             rangeContext_->reset(true);
+            forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
             update();
         }
         void assign(std::initializer_list<value_type> ilist)
         {
             contained_.assign(ilist);
             rangeContext_->reset(true);
+            forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
             update();
         }
 
@@ -957,6 +961,7 @@ namespace Nui
         {
             contained_.clear();
             rangeContext_->reset(true);
+            forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
             update();
         }
         template <typename U = ContainerT>
@@ -969,6 +974,7 @@ namespace Nui
 
             const auto result = contained_.insert(value);
             rangeContext_->performFullRangeUpdate();
+            forEachReaderContext([](RangeEventContext& c) { c.performFullRangeUpdate(); });
             update();
             ObservedBase::eventContext_->executeActiveEventsImmediately();
             return result;
@@ -983,6 +989,7 @@ namespace Nui
 
             const auto result = contained_.insert(std::move(value));
             rangeContext_->performFullRangeUpdate();
+            forEachReaderContext([](RangeEventContext& c) { c.performFullRangeUpdate(); });
             update();
             ObservedBase::eventContext_->executeActiveEventsImmediately();
             return result;
@@ -1184,6 +1191,7 @@ namespace Nui
         {
             contained_.swap(other);
             rangeContext_->reset(true);
+            forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
             update();
         }
 
@@ -1206,14 +1214,17 @@ namespace Nui
         }
         void attachReaderContext(std::shared_ptr<RangeEventContext> const& ctx) const
         {
-            readerContexts_.emplace_back(ctx);
+            readerContexts_->emplace_back(ctx);
         }
 
       protected:
         void update(bool force = false) const override
         {
             if (force)
+            {
                 rangeContext_->reset(true);
+                forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
+            }
             ObservedBase::eventContext_->activateAfterEffect(afterEffectId_);
             ObservedBase::update(force);
         }
@@ -1222,8 +1233,9 @@ namespace Nui
         template <typename Fn>
         void forEachReaderContext(Fn const& fn) const
         {
-            auto it = readerContexts_.begin();
-            while (it != readerContexts_.end())
+            auto& readers = *readerContexts_;
+            auto it = readers.begin();
+            while (it != readers.end())
             {
                 if (auto shared = it->lock())
                 {
@@ -1232,7 +1244,7 @@ namespace Nui
                 }
                 else
                 {
-                    it = readerContexts_.erase(it);
+                    it = readers.erase(it);
                 }
             }
         }
@@ -1244,6 +1256,7 @@ namespace Nui
                 NUI_ASSERT(ObservedBase::eventContext_ != nullptr, "Event context must never be null.");
 
                 const auto result = rangeContext_->insertModificationRange(low, high, type);
+                forEachReaderContext([&](RangeEventContext& c) { c.insertModificationRange(low, high, type); });
                 if (result == RangeEventContext::InsertResult::Perform)
                 {
                     update();
@@ -1259,6 +1272,7 @@ namespace Nui
                     else
                     {
                         rangeContext_->reset(true);
+                        forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
                         update();
                         ObservedBase::eventContext_->executeActiveEventsImmediately();
                         return;
@@ -1272,6 +1286,7 @@ namespace Nui
                 {
                     // Rejected! (why?)
                     rangeContext_->reset(true);
+                    forEachReaderContext([](RangeEventContext& c) { c.reset(true); });
                     update();
                     ObservedBase::eventContext_->executeActiveEventsImmediately();
                     return;
@@ -1285,19 +1300,29 @@ namespace Nui
         {
             NUI_ASSERT(ObservedBase::eventContext_ != nullptr, "Event context must never be null.");
             return ObservedBase::eventContext_->registerAfterEffect(
-                Event{[weak = std::weak_ptr<RangeEventContext>{rangeContext_}](EventContext::EventIdType) {
-                    if (auto shared = weak.lock(); shared)
+                Event{[weak = std::weak_ptr<RangeEventContext>{rangeContext_},
+                       weakReaders = std::weak_ptr<std::vector<std::weak_ptr<RangeEventContext>>>{
+                           readerContexts_}](EventContext::EventIdType) {
+                    auto shared = weak.lock();
+                    if (!shared)
+                        return false;
+                    shared->reset();
+                    if (auto sharedReaders = weakReaders.lock())
                     {
-                        shared->reset();
-                        return true;
+                        for (auto& w : *sharedReaders)
+                        {
+                            if (auto r = w.lock())
+                                r->reset();
+                        }
                     }
-                    return false;
+                    return true;
                 }});
         }
 
         void eraseNotify(std::size_t index, std::size_t high)
         {
             const bool fixupPerformed = rangeContext_->eraseNotify(index, high);
+            forEachReaderContext([&](RangeEventContext& c) { c.eraseNotify(index, high); });
             if (fixupPerformed) // FORCE update:
             {
                 update();
@@ -1308,8 +1333,9 @@ namespace Nui
       protected:
         MoveDetector moveDetector_;
         mutable std::shared_ptr<RangeEventContext> rangeContext_;
+        mutable std::shared_ptr<std::vector<std::weak_ptr<RangeEventContext>>> readerContexts_{
+            std::make_shared<std::vector<std::weak_ptr<RangeEventContext>>>()};
         mutable EventContext::EventIdType afterEffectId_;
-        mutable std::vector<std::weak_ptr<RangeEventContext>> readerContexts_;
     };
 
     template <typename T, typename Tags = void>

--- a/nui/include/nui/event_system/range_event_context.hpp
+++ b/nui/include/nui/event_system/range_event_context.hpp
@@ -285,6 +285,10 @@ namespace Nui
         {
             return fullRangeUpdate_;
         }
+        void setDisableOptimizations(bool disable) noexcept
+        {
+            disableOptimizations_ = disable;
+        }
         auto begin() const
         {
             return trackedRanges_.begin();

--- a/nui/include/nui/frontend/elements/impl/range_renderer.tpp
+++ b/nui/include/nui/frontend/elements/impl/range_renderer.tpp
@@ -106,11 +106,22 @@ namespace Nui::Detail
         virtual bool updateChildren(bool initial) = 0;
 
       protected:
+        RangeEventContext& ownContext()
+        {
+            return *ownContext_;
+        }
+        std::shared_ptr<RangeEventContext> const& ownContextPtr() const
+        {
+            return ownContext_;
+        }
+
+      protected:
         GeneratorT elementRenderer_;
         std::weak_ptr<Nui::Dom::Element> weakMaterialized_;
         RendererVector before_;
         RendererVector after_;
         std::size_t renderedBeforeCount_{0};
+        std::shared_ptr<RangeEventContext> ownContext_{std::make_shared<RangeEventContext>()};
 
       private:
         ObservedAddMutableReference_t<ObservedType> valueRange_;
@@ -232,6 +243,7 @@ namespace Nui::Detail
             auto* valueRange = getValueRange(valueRangeHolder);
             if (valueRange)
             {
+                valueRange->attachReaderContext(this->ownContextPtr());
                 valueRange->attachEvent(
                     Nui::globalEventContext.registerEvent(
                         Event{
@@ -276,6 +288,7 @@ namespace Nui::Detail
             auto* valueRange = getValueRange(valueRangeHolder);
             if (valueRange)
             {
+                valueRange->attachReaderContext(this->ownContextPtr());
                 valueRange->attachEvent(
                     Nui::globalEventContext.registerEvent(
                         Event{

--- a/nui/include/nui/frontend/elements/impl/range_renderer.tpp
+++ b/nui/include/nui/frontend/elements/impl/range_renderer.tpp
@@ -84,7 +84,7 @@ namespace Nui::Detail
             if (valueRange == nullptr)
                 return false;
 
-            if (valueRange->rangeContext().isFullRangeUpdate() || force)
+            if (ownContext().isFullRangeUpdate() || force)
             {
                 parent->clearChildren();
                 if (!before_.empty())
@@ -94,7 +94,7 @@ namespace Nui::Detail
                 long long counter = 0;
                 for (auto& element : valueRange->value())
                     elementRenderer_(counter++, element)(*parent, Renderer{.type = RendererType::Append});
-                valueRange->rangeContext().reset();
+                ownContext().reset();
 
                 if (!after_.empty())
                     parent->appendElements(after_);
@@ -138,6 +138,7 @@ namespace Nui::Detail
         using BasicObservedRenderer<RangeT, GeneratorT>::elementRenderer_;
         using BasicObservedRenderer<RangeT, GeneratorT>::fullRangeUpdate;
         using BasicObservedRenderer<RangeT, GeneratorT>::getValueRange;
+        using BasicObservedRenderer<RangeT, GeneratorT>::ownContext;
         using BasicObservedRenderer<RangeT, GeneratorT>::before_;
         using BasicObservedRenderer<RangeT, GeneratorT>::after_;
         using BasicObservedRenderer<RangeT, GeneratorT>::renderedBeforeCount_;
@@ -149,7 +150,7 @@ namespace Nui::Detail
             if (valueRange == nullptr)
                 return;
 
-            for (auto i = valueRange->rangeContext().begin(), end = valueRange->rangeContext().end(); i != end; ++i)
+            for (auto i = ownContext().begin(), end = ownContext().end(); i != end; ++i)
             {
                 for (auto r = i->low(), high = i->high(); r <= high; ++r)
                 {
@@ -169,7 +170,7 @@ namespace Nui::Detail
             if (valueRange == nullptr)
                 return;
 
-            for (auto const& range : valueRange->rangeContext())
+            for (auto const& range : ownContext())
             {
                 using RangeValueType = typename std::decay_t<decltype(range)>::value_type;
                 const auto clampedLow = std::max(range.low(), RangeValueType{0});
@@ -193,7 +194,7 @@ namespace Nui::Detail
             if (valueRange == nullptr)
                 return;
 
-            for (auto const& eraseRange : reverse_view{valueRange->rangeContext()})
+            for (auto const& eraseRange : reverse_view{ownContext()})
             {
                 parent->erase(
                     begin(*parent) + eraseRange.low() + renderedBeforeCount_,
@@ -217,7 +218,7 @@ namespace Nui::Detail
             if (fullRangeUpdate(parent, initial))
                 return KeepRange;
 
-            switch (valueRange->rangeContext().operationType())
+            switch (ownContext().operationType())
             {
                 case RangeOperationType::Insert:
                     insertions(parent);

--- a/nui/test/nui/engine/document.cpp
+++ b/nui/test/nui/engine/document.cpp
@@ -31,7 +31,59 @@ namespace Nui::Tests::Engine
         {
             auto elem = Nui::val::object();
             elem.set("replaceWith", Function{[self = elem](Nui::val value) mutable -> Nui::val {
-                         *self.handle() = *value.handle();
+                         bool replacedInParent = false;
+                         if (value.hasOwnProperty("parentNode"))
+                         {
+                             auto otherParent = value["parentNode"];
+                             if (!otherParent.isUndefined() && !otherParent.isNull())
+                                 otherParent.call<void>("removeChild", value);
+                         }
+                         if (self.hasOwnProperty("parentNode"))
+                         {
+                             auto parent = self["parentNode"];
+                             if (!parent.isUndefined() && !parent.isNull() &&
+                                 parent.hasOwnProperty("children"))
+                             {
+                                 auto replaceIn = [&](Array& container) {
+                                     auto it = std::find(
+                                         container.begin(), container.end(), self.handle());
+                                     if (it != container.end())
+                                     {
+                                         const auto pos = std::distance(container.begin(), it);
+                                         container.erase(it);
+                                         container.insert(
+                                             container.begin() + pos, value.handle());
+                                         replacedInParent = true;
+                                     }
+                                 };
+                                 replaceIn(parent["children"].template as<Array&>());
+                                 replaceIn(parent["childNodes"].template as<Array&>());
+                                 if (replacedInParent)
+                                     value.set("parentNode", parent);
+                             }
+                         }
+                         // Fallback for elements without a real parent in the mock DOM
+                         // (e.g. document.body during initial setBody): redirect self's
+                         // shared ReferenceType to value's underlying allValues entry so
+                         // any global lookups (Nui::val::global("document")["body"]) see
+                         // the replacement.
+                         if (!replacedInParent)
+                         {
+                             // If self is currently document.body, also rebind that
+                             // slot to value's shared_ptr. Otherwise a chain of body
+                             // replaces (multiple render() calls in the same test)
+                             // leaves document.body following a stale shared_ptr
+                             // whose ReferenceType was redirected by an earlier
+                             // replace but never updated again.
+                             const bool isDocumentBody = globalObject.has("document") && [&] {
+                                 auto doc = Nui::val::global("document");
+                                 return doc.hasOwnProperty("body") &&
+                                     *doc["body"].handle() == *self.handle();
+                             }();
+                             *self.handle() = *value.handle();
+                             if (isDocumentBody)
+                                 Nui::val::global("document").set("body", value);
+                         }
                          return self;
                      }});
             elem.set("remove", Function{[self = elem]() -> Nui::val {

--- a/nui/test/nui/test_ranges.hpp
+++ b/nui/test/nui/test_ranges.hpp
@@ -1958,6 +1958,467 @@ namespace Nui::Tests
         EXPECT_TRUE(vec.rangeContext().isInDefaultState());
     }
 
+    // ---------------------------------------------------------------------
+    // Multi-subscriber tests for the fullRangeUpdate path
+    // ---------------------------------------------------------------------
+    // These exercise mutations that set rangeContext.fullRangeUpdate_=true
+    // (clear, operator=, swap, assign). Currently buggy: the first range
+    // subscriber consumes the shared rangeContext via reset(), leaving the
+    // second subscriber with nothing to render. After the per-subscriber
+    // context refactor these will pass.
+
+    TEST_F(TestRanges, MultiSubscriber_ClearThenPushBack)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
+
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        vec.clear();
+        vec.push_back('A');
+        vec.push_back('B');
+        globalEventContext.executeActiveEventsImmediately();
+
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_AssignNewVector)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
+
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        vec = std::vector<char>{'X', 'Y', 'Z'};
+        globalEventContext.executeActiveEventsImmediately();
+
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_Swap)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
+
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        std::vector<char> other{'P', 'Q'};
+        vec.swap(other);
+        globalEventContext.executeActiveEventsImmediately();
+
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_AssignViaInitializerList)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
+
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        vec.assign({'M', 'N', 'O', 'P'});
+        globalEventContext.executeActiveEventsImmediately();
+
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    // ---------------------------------------------------------------------
+    // Multi-subscriber tests for the per-operation paths (Insert/Modify/
+    // Erase). These exercise the path where rangeContext stays through the
+    // event cycle and is reset by the registered afterEffect rather than
+    // eagerly by the renderer. Most should already pass today; they are
+    // here to lock the contract in once per-subscriber contexts land.
+
+    TEST_F(TestRanges, MultiSubscriber_PushBack)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::vector<char>> vec{{'A', 'B', 'C'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        vec.push_back('D');
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_PopBack)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        vec.pop_back();
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_PushFront_Deque)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::deque<char>> deq{{'A', 'B', 'C'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(deq), renderer), div{reference = parent2}(range(deq), renderer)));
+
+        deq.push_front('Z');
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(deq, parent1);
+        textBodyParityTest(deq, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_PopFront_Deque)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::deque<char>> deq{{'A', 'B', 'C', 'D'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(deq), renderer), div{reference = parent2}(range(deq), renderer)));
+
+        deq.pop_front();
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(deq, parent1);
+        textBodyParityTest(deq, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_EmplaceBack)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::vector<char>> vec{{'A', 'B', 'C'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        vec.emplace_back('D');
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_EmplaceFront_Deque)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::deque<char>> deq{{'A', 'B', 'C'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(deq), renderer), div{reference = parent2}(range(deq), renderer)));
+
+        deq.emplace_front('Z');
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(deq, parent1);
+        textBodyParityTest(deq, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_Insert_PosValue)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        vec.insert(vec.begin() + 2, 'X');
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_Insert_PosCountValue)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        vec.insert(vec.begin() + 2, 3, 'Z');
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_Insert_PosFirstLast)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        std::vector<char> source{'X', 'Y'};
+        vec.insert(vec.begin() + 2, source.begin(), source.end());
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_Insert_PosInitList)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        vec.insert(vec.begin() + 2, {'1', '2', '3'});
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_Erase_Pos)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        vec.erase(vec.begin() + 1);
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_Erase_FirstLast)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D', 'E'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        vec.erase(vec.begin() + 1, vec.begin() + 4);
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_Resize_Grow)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::vector<char>> vec{{'A', 'B', 'C'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        vec.resize(6);
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_Resize_Shrink)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D', 'E'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        vec.resize(2);
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_Resize_GrowWithFill)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::vector<char>> vec{{'A', 'B', 'C'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        vec.resize(6, 'F');
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_IndexedAssign)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        vec[2] = 'X';
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_IteratorDerefAssign)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        *(vec.begin() + 1) = 'Y';
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_MixedSequence)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
+
+        vec.push_back('E');
+        vec[0] = 'X';
+        vec.erase(vec.begin() + 2);
+        vec.insert(vec.begin(), '_');
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+    }
+
     TEST_F(TestRanges, CanRenderRangeEvenDuringPendingModification)
     {
         Nui::val parent1;

--- a/nui/test/nui/test_ranges.hpp
+++ b/nui/test/nui/test_ranges.hpp
@@ -2397,7 +2397,7 @@ namespace Nui::Tests
         textBodyParityTest(vec, parent2);
     }
 
-    TEST_F(TestRanges, MultiSubscriber_MixedSequence)
+    TEST_F(TestRanges, DISABLED_MultiSubscriber_MixedSequence)
     {
         Nui::val parent1;
         Nui::val parent2;
@@ -2417,6 +2417,20 @@ namespace Nui::Tests
         globalEventContext.executeActiveEventsImmediately();
         textBodyParityTest(vec, parent1);
         textBodyParityTest(vec, parent2);
+    }
+
+    TEST_F(TestRanges, DISABLED_SingleSubscriber_MixedSequence_DiagnosticControl)
+    {
+        Nui::val parent;
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
+        rangeTextBodyRender(vec, parent);
+
+        vec.push_back('E');
+        vec[0] = 'X';
+        vec.erase(vec.begin() + 2);
+        vec.insert(vec.begin(), '_');
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parent);
     }
 
     TEST_F(TestRanges, CanRenderRangeEvenDuringPendingModification)

--- a/nui/test/nui/test_ranges.hpp
+++ b/nui/test/nui/test_ranges.hpp
@@ -1934,30 +1934,6 @@ namespace Nui::Tests
         EXPECT_EQ(this->aggregateObservedCharList(vec), this->getChildrenBodyTextConcat(parent2));
     }
 
-    TEST_F(TestRanges, RangeContextIsResetAfterAllChildrenAreRendered)
-    {
-        Nui::val parent1;
-        Nui::val parent2;
-
-        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
-
-        using Nui::Elements::div;
-        using Nui::Elements::body;
-        using namespace Nui::Attributes;
-
-        auto renderer = [&vec](long long i, auto const& element) -> Nui::ElementRenderer {
-            return div{}(std::string{element});
-        };
-
-        render(body{}(div{reference = parent1}(range(vec), renderer), div{reference = parent2}(range(vec), renderer)));
-
-        vec.push_back('E');
-        vec[0] = 'X';
-        globalEventContext.executeActiveEventsImmediately();
-
-        EXPECT_TRUE(vec.rangeContext().isInDefaultState());
-    }
-
     // ---------------------------------------------------------------------
     // Multi-subscriber tests for the fullRangeUpdate path
     // ---------------------------------------------------------------------

--- a/nui/test/nui/test_ranges.hpp
+++ b/nui/test/nui/test_ranges.hpp
@@ -2373,7 +2373,7 @@ namespace Nui::Tests
         textBodyParityTest(vec, parent2);
     }
 
-    TEST_F(TestRanges, DISABLED_MultiSubscriber_MixedSequence)
+    TEST_F(TestRanges, MultiSubscriber_MixedSequence)
     {
         Nui::val parent1;
         Nui::val parent2;
@@ -2395,7 +2395,7 @@ namespace Nui::Tests
         textBodyParityTest(vec, parent2);
     }
 
-    TEST_F(TestRanges, DISABLED_SingleSubscriber_MixedSequence_DiagnosticControl)
+    TEST_F(TestRanges, SingleSubscriber_MixedSequence_DiagnosticControl)
     {
         Nui::val parent;
         Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
@@ -2407,6 +2407,519 @@ namespace Nui::Tests
         vec.insert(vec.begin(), '_');
         globalEventContext.executeActiveEventsImmediately();
         textBodyParityTest(vec, parent);
+    }
+
+    TEST_F(TestRanges, SetInsertReplacesNotAppends)
+    {
+        Nui::val parent;
+        Observed<std::set<char>> s{{'A', 'B', 'C'}};
+
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+
+        render(body{reference = parent}(range(s), [](long long, auto const& element) {
+            return div{}(std::string{element});
+        }));
+        ASSERT_EQ(parent["children"]["length"].as<long long>(), 3);
+
+        s.insert('D');
+        globalEventContext.executeActiveEventsImmediately();
+        EXPECT_EQ(parent["children"]["length"].as<long long>(), 4);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_SetInsertReplacesNotAppends)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::set<char>> s{{'A', 'B', 'C'}};
+
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(
+            div{reference = parent1}(range(s), renderer),
+            div{reference = parent2}(range(s), renderer)));
+
+        ASSERT_EQ(parent1["children"]["length"].as<long long>(), 3);
+        ASSERT_EQ(parent2["children"]["length"].as<long long>(), 3);
+
+        s.insert('D');
+        globalEventContext.executeActiveEventsImmediately();
+        EXPECT_EQ(parent1["children"]["length"].as<long long>(), 4);
+        EXPECT_EQ(parent2["children"]["length"].as<long long>(), 4);
+    }
+
+    TEST_F(TestRanges, MultiSubscriber_AfterPriorBodyReplace_SetInsert)
+    {
+        // Reproduces the failure-in-context: a prior render+mutation cycle
+        // before the set scope causes the set's insert to double-render its
+        // parents. Standalone the test passes; this minimizes the
+        // surrounding state to identify what leaks.
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+
+        {
+            Nui::val deqp1;
+            Nui::val deqp2;
+            Observed<std::deque<char>> deq{{'A', 'B'}};
+            auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+                return div{}(std::string{element});
+            };
+            render(body{}(
+                div{reference = deqp1}(range(deq), renderer),
+                div{reference = deqp2}(range(deq), renderer)));
+            deq.push_back('C');
+            globalEventContext.executeActiveEventsImmediately();
+        }
+
+        Nui::val parent1;
+        Nui::val parent2;
+        Observed<std::set<char>> s{{'A', 'B', 'C'}};
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+        render(body{}(
+            div{reference = parent1}(range(s), renderer),
+            div{reference = parent2}(range(s), renderer)));
+
+        ASSERT_EQ(parent1["children"]["length"].as<long long>(), 3);
+        ASSERT_EQ(parent2["children"]["length"].as<long long>(), 3);
+
+        s.insert('D');
+        globalEventContext.executeActiveEventsImmediately();
+        EXPECT_EQ(parent1["children"]["length"].as<long long>(), 4);
+        EXPECT_EQ(parent2["children"]["length"].as<long long>(), 4);
+    }
+
+    TEST_F(TestRanges, RepeatedIndexedAssignAtSamePosition)
+    {
+        // Regression: repeated Replace ops at the same position used to leave
+        // the parent's mock children array referencing the very first
+        // replacement, because replaceElementImpl reassigns element_ to the
+        // new replacement after replaceWith and the mock's replaceWith only
+        // redirected the original handle.
+        Nui::val parent;
+        Observed<std::vector<int>> vec{{0, 0, 0}};
+
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+
+        render(body{reference = parent}(range(vec), [](long long, auto const& element) {
+            return div{}(std::to_string(element));
+        }));
+        EXPECT_EQ(parent["children"][1]["textContent"].as<std::string>(), std::string{"0"});
+
+        vec[1] = 100;
+        globalEventContext.executeActiveEventsImmediately();
+        EXPECT_EQ(parent["children"][1]["textContent"].as<std::string>(), std::string{"100"});
+
+        vec[1] = 200;
+        globalEventContext.executeActiveEventsImmediately();
+        EXPECT_EQ(parent["children"][1]["textContent"].as<std::string>(), std::string{"200"});
+
+        vec[1] = 300;
+        globalEventContext.executeActiveEventsImmediately();
+        EXPECT_EQ(parent["children"][1]["textContent"].as<std::string>(), std::string{"300"});
+    }
+
+    // ---------------------------------------------------------------------
+    // Subscriber lifecycle and stress tests
+    // ---------------------------------------------------------------------
+
+    TEST_F(TestRanges, SubscriberLifetime_Detach)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+
+        Observed<bool> showSecond{false};
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
+
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+
+        // clang-format off
+        render(
+            body{}(
+                div{reference = parent1}(range(vec), renderer),
+                div{}(
+                    observe(showSecond),
+                    [&parent2, &vec, &renderer, &showSecond]() -> Nui::ElementRenderer {
+                        if (!showSecond.value())
+                            return Nui::nil();
+                        return div{reference = parent2}(range(vec), renderer);
+                    }
+                )
+            )
+        );
+        // clang-format on
+
+        EXPECT_EQ(vec.readerContextCount(), 1u);
+
+        showSecond = true;
+        globalEventContext.executeActiveEventsImmediately();
+        EXPECT_EQ(vec.readerContextCount(), 2u);
+        textBodyParityTest(vec, parent1);
+        textBodyParityTest(vec, parent2);
+
+        showSecond = false;
+        globalEventContext.executeActiveEventsImmediately();
+
+        // First mutation tears down the dead subscriber's renderer (its event
+        // returns false from its action), but at this point its own
+        // forEachReaderContext iteration already saw the weak_ptr alive.
+        vec.push_back('E');
+        globalEventContext.executeActiveEventsImmediately();
+        // Second mutation prunes the now-expired weak_ptr.
+        vec.push_back('F');
+        globalEventContext.executeActiveEventsImmediately();
+
+        EXPECT_EQ(vec.readerContextCount(), 1u);
+        textBodyParityTest(vec, parent1);
+    }
+
+    TEST_F(TestRanges, SubscriberLifetime_DiesMidBroadcast)
+    {
+        Nui::val parent1;
+        Nui::val parent2;
+
+        Observed<bool> showSecond{true};
+        Observed<std::vector<char>> vec{{'A', 'B', 'C', 'D'}};
+
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+
+        // clang-format off
+        render(
+            body{}(
+                div{reference = parent1}(range(vec), renderer),
+                div{}(
+                    observe(showSecond),
+                    [&parent2, &vec, &renderer, &showSecond]() -> Nui::ElementRenderer {
+                        if (!showSecond.value())
+                            return Nui::nil();
+                        return div{reference = parent2}(range(vec), renderer);
+                    }
+                )
+            )
+        );
+        // clang-format on
+
+        EXPECT_EQ(vec.readerContextCount(), 2u);
+
+        // Kill the second subscriber and immediately mutate. The broadcast must
+        // tolerate an expired weak_ptr without crashing and the survivor must
+        // stay in sync.
+        showSecond = false;
+        vec.push_back('E');
+        vec.push_back('F');
+        globalEventContext.executeActiveEventsImmediately();
+
+        textBodyParityTest(vec, parent1);
+
+        vec.erase(vec.begin());
+        vec.insert(vec.begin() + 1, 'Z');
+        globalEventContext.executeActiveEventsImmediately();
+
+        textBodyParityTest(vec, parent1);
+        EXPECT_EQ(vec.readerContextCount(), 1u);
+    }
+
+    TEST_F(TestRanges, FiveSubscribers_RandomMutations)
+    {
+        std::array<Nui::val, 5> parents;
+        Observed<std::vector<int>> vec{{0, 1, 2, 3, 4, 5, 6, 7}};
+
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::to_string(element));
+        };
+
+        // clang-format off
+        render(body{}(
+            div{reference = parents[0]}(range(vec), renderer),
+            div{reference = parents[1]}(range(vec), renderer),
+            div{reference = parents[2]}(range(vec), renderer),
+            div{reference = parents[3]}(range(vec), renderer),
+            div{reference = parents[4]}(range(vec), renderer)
+        ));
+        // clang-format on
+
+        EXPECT_EQ(vec.readerContextCount(), 5u);
+
+        // Cycle through the supported single-type ops in batches, flushing
+        // between each. This stresses the broadcast loop with five readers
+        // without crossing into the parked PerformAndRetry-with-mixed-types
+        // territory (DISABLED_*).
+        std::mt19937 rng{0xC0FFEEu};
+        const auto runBatch = [&](int op, int count) {
+            for (int n = 0; n != count; ++n)
+            {
+                const auto size = vec.size();
+                switch (op)
+                {
+                    case 0: // push_back
+                        vec.push_back(n);
+                        break;
+                    case 1: // pop_back
+                        if (size > 0u)
+                            vec.pop_back();
+                        break;
+                    case 2: // insert
+                    {
+                        std::uniform_int_distribution<std::size_t> posDist{0u, size};
+                        const auto pos = posDist(rng);
+                        vec.insert(vec.begin() + static_cast<std::ptrdiff_t>(pos), -n);
+                        break;
+                    }
+                    case 3: // erase
+                        if (size > 0u)
+                        {
+                            std::uniform_int_distribution<std::size_t> posDist{0u, size - 1u};
+                            const auto pos = posDist(rng);
+                            vec.erase(vec.begin() + static_cast<std::ptrdiff_t>(pos));
+                        }
+                        break;
+                    case 4: // indexed assign
+                        if (size > 0u)
+                        {
+                            std::uniform_int_distribution<std::size_t> posDist{0u, size - 1u};
+                            const auto pos = posDist(rng);
+                            vec[pos] = 1000 + n;
+                        }
+                        break;
+                }
+                globalEventContext.executeActiveEventsImmediately();
+            }
+            std::string source;
+            for (auto v : vec.value())
+                source += std::to_string(v) + ",";
+            for (std::size_t pIdx = 0; pIdx != parents.size(); ++pIdx)
+            {
+                auto const& parent = parents[pIdx];
+                ASSERT_EQ(parent["children"]["length"].as<long long>(), static_cast<long long>(vec.size()))
+                    << "parent[" << pIdx << "] op " << op;
+                std::string viewReality;
+                for (long long i = 0, end = parent["children"]["length"].as<long long>(); i != end; ++i)
+                    viewReality += parent["children"][i]["textContent"].as<std::string>() + ",";
+                ASSERT_EQ(source, viewReality) << "parent[" << pIdx << "] op " << op;
+            }
+        };
+
+        runBatch(0, 20); // push_back x 20
+        runBatch(4, 20); // indexed assign x 20
+        runBatch(2, 20); // insert x 20
+        runBatch(3, 20); // erase x 20
+        runBatch(1, 5); // pop_back x 5
+        runBatch(4, 20); // indexed assign x 20 (post-mutation)
+
+        EXPECT_EQ(vec.readerContextCount(), 5u);
+    }
+
+    TEST_F(TestRanges, InteractionAcrossSubscribers)
+    {
+        // Subscribers attached at different points in time must all converge
+        // to the same view of the container after later mutations.
+        Nui::val parentEarly;
+        Nui::val parentLate;
+
+        Observed<bool> mountLate{false};
+        Observed<std::vector<char>> vec{{'A', 'B', 'C'}};
+
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+
+        // clang-format off
+        render(
+            body{}(
+                div{reference = parentEarly}(range(vec), renderer),
+                div{}(
+                    observe(mountLate),
+                    [&parentLate, &vec, &renderer, &mountLate]() -> Nui::ElementRenderer {
+                        if (!mountLate.value())
+                            return Nui::nil();
+                        return div{reference = parentLate}(range(vec), renderer);
+                    }
+                )
+            )
+        );
+        // clang-format on
+
+        // First mutate while only the early subscriber is mounted.
+        vec.push_back('D');
+        vec.push_back('E');
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parentEarly);
+
+        // Mount the late subscriber. It should render the current state.
+        mountLate = true;
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(vec, parentEarly);
+        textBodyParityTest(vec, parentLate);
+        EXPECT_EQ(vec.readerContextCount(), 2u);
+
+        // Now mutate again. Both subscribers must agree.
+        vec.erase(vec.begin() + 1);
+        globalEventContext.executeActiveEventsImmediately();
+        vec.insert(vec.begin(), 'Z');
+        globalEventContext.executeActiveEventsImmediately();
+        vec[0] = 'Q';
+        globalEventContext.executeActiveEventsImmediately();
+
+        textBodyParityTest(vec, parentEarly);
+        textBodyParityTest(vec, parentLate);
+    }
+
+    TEST_F(TestRanges, OperatorAssignBetweenContainers)
+    {
+        Nui::val parentA1;
+        Nui::val parentA2;
+
+        Observed<std::vector<char>> a{{'A', 'B', 'C'}};
+        Observed<std::vector<char>> b{{'X', 'Y', 'Z', 'W'}};
+
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+
+        auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+            return div{}(std::string{element});
+        };
+
+        render(body{}(
+            div{reference = parentA1}(range(a), renderer), div{reference = parentA2}(range(a), renderer)));
+
+        EXPECT_EQ(a.readerContextCount(), 2u);
+        EXPECT_EQ(b.readerContextCount(), 0u);
+
+        a = std::move(b.value());
+        globalEventContext.executeActiveEventsImmediately();
+
+        textBodyParityTest(a, parentA1);
+        textBodyParityTest(a, parentA2);
+
+        // b is unrendered; mutating it must not affect a's subscribers.
+        b = std::vector<char>{'1', '2'};
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(a, parentA1);
+        textBodyParityTest(a, parentA2);
+    }
+
+    TEST_F(TestRanges, Map_Set_Deque_MultiSubscriber)
+    {
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+
+        // deque
+        {
+            Nui::val parent1;
+            Nui::val parent2;
+            Observed<std::deque<char>> deq{{'A', 'B', 'C', 'D'}};
+            auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+                return div{}(std::string{element});
+            };
+            render(body{}(
+                div{reference = parent1}(range(deq), renderer), div{reference = parent2}(range(deq), renderer)));
+
+            deq.push_front('Z');
+            globalEventContext.executeActiveEventsImmediately();
+            textBodyParityTest(deq, parent1);
+            textBodyParityTest(deq, parent2);
+
+            deq.push_back('E');
+            globalEventContext.executeActiveEventsImmediately();
+            textBodyParityTest(deq, parent1);
+            textBodyParityTest(deq, parent2);
+
+            EXPECT_EQ(deq.readerContextCount(), 2u);
+        }
+
+        // set
+        {
+            Nui::val parent1;
+            Nui::val parent2;
+            Observed<std::set<char>> s{{'A', 'B', 'C'}};
+            auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+                return div{}(std::string{element});
+            };
+            render(body{}(
+                div{reference = parent1}(range(s), renderer), div{reference = parent2}(range(s), renderer)));
+
+            EXPECT_EQ(parent1["children"]["length"].as<long long>(), static_cast<long long>(s.size()));
+            EXPECT_EQ(parent2["children"]["length"].as<long long>(), static_cast<long long>(s.size()));
+
+            s.insert('D');
+            globalEventContext.executeActiveEventsImmediately();
+            EXPECT_EQ(parent1["children"]["length"].as<long long>(), static_cast<long long>(s.size()));
+            EXPECT_EQ(parent2["children"]["length"].as<long long>(), static_cast<long long>(s.size()));
+
+            s.insert('Z');
+            globalEventContext.executeActiveEventsImmediately();
+            EXPECT_EQ(parent1["children"]["length"].as<long long>(), static_cast<long long>(s.size()));
+            EXPECT_EQ(parent2["children"]["length"].as<long long>(), static_cast<long long>(s.size()));
+
+            EXPECT_EQ(s.readerContextCount(), 2u);
+        }
+
+        // map: routed through UnoptimizedRangeRenderer rather than the
+        // per-subscriber-context path. Verify both subscribers render the
+        // initial state.
+        {
+            Nui::val parent1;
+            Nui::val parent2;
+            Observed<std::map<int, char>> m{{{1, 'A'}, {2, 'B'}, {3, 'C'}}};
+            auto renderer = [](long long, auto const& element) -> Nui::ElementRenderer {
+                return div{}(std::to_string(element.first) + ":" + std::string{element.second});
+            };
+            render(body{}(
+                div{reference = parent1}(range(m), renderer), div{reference = parent2}(range(m), renderer)));
+
+            EXPECT_EQ(parent1["children"]["length"].as<long long>(), static_cast<long long>(m->size()));
+            EXPECT_EQ(parent2["children"]["length"].as<long long>(), static_cast<long long>(m->size()));
+        }
+    }
+
+    TEST_F(TestRanges, MoveAssignedObservedHasNoSubscribers)
+    {
+        // A freshly-constructed Observed has no subscribers until rendered.
+        Observed<std::vector<char>> fresh{{'A', 'B'}};
+        EXPECT_EQ(fresh.readerContextCount(), 0u);
+
+        // After replacing the value via operator=(T&&) but without any range()
+        // having been bound, there must still be no subscribers.
+        fresh = std::vector<char>{'X', 'Y', 'Z'};
+        globalEventContext.executeActiveEventsImmediately();
+        EXPECT_EQ(fresh.readerContextCount(), 0u);
+
+        // .assign() likewise must not create subscribers.
+        fresh.assign({'P', 'Q', 'R', 'S'});
+        globalEventContext.executeActiveEventsImmediately();
+        EXPECT_EQ(fresh.readerContextCount(), 0u);
     }
 
     TEST_F(TestRanges, CanRenderRangeEvenDuringPendingModification)


### PR DESCRIPTION
# Fix multi ranges - PR changelog

## Summary

`Observed<T>` now lets multiple consumers subscribe to the same container without stepping on each other. Previously, `RangeEventContext` was a producer-side singleton on the `Observed`, so two `Nui::range(vec)` subscribers shared one diff state and each `consume`-and-`reset` raced the other: only the first subscriber to render saw the update.

This PR moves `RangeEventContext` to be per-consumer, owned by each `BasicObservedRenderer`, and has the producer broadcast change events to all live readers.

Example:
```c++
#include <nui/frontend.hpp>

using namespace Nui;
using namespace Nui::Elements;
using namespace Nui::Attributes;

void example()
{
    Observed<std::vector<std::string>> items{{"alpha", "beta", "gamma"}};

    auto renderItem = [](long long, auto const& s) -> ElementRenderer {
        return li{}(s);
    };

    // Two views over the same Observed:
    //   - a sidebar list
    //   - a footer count + repeated list
    //
    // Before this PR, only the first range() to render would receive
    // updates; the second silently fell behind because both shared the
    // Observed's single internal RangeEventContext.
    //
    // After this PR, both stay in sync.
    return body{}(
        div{class_ = "sidebar"}(
            ul{}(range(items), renderItem)
        ),
        div{class_ = "footer"}(
            span{}([&items]() { return std::to_string(items.size()) + " items"; }),
            ul{}(range(items), renderItem)   // <-- same Observed, second subscriber
        )
    );

    // items.push_back("delta");           // both lists grow
    // items[0] = "alpha-renamed";         // both lists update at index 0
    // items.erase(items.begin() + 1);     // both lists shrink
}
```

## Breaking changes

- `ObservedContainer::rangeContext()` (both overloads) **removed** — the range event context is now an implementation detail of range rendering, not a property of the observed value.
- `ObservedContainer` constructors taking `RangeEventContext&&` (4 overloads) **removed**.

These were unused outside the test suite; if you somehow held one, replace with the default constructor.
Because of that I consider this change not major version increasing, because its likely 0 impact.

## Behavior changes

- Multiple `Nui::range(observed)` subscribers over the same `Observed<vector|deque|string|set|list>` now all stay in sync across mutations. Previously the second-and-later subscribers would silently fall behind.
- `Observed<set>` and `Observed<list>` automatically opt their attached reader contexts into `disableOptimizations=true`, since their non-random-access iteration model can't replay the optimized diff path.

## New API

- `ObservedContainer::attachReaderContext(std::shared_ptr<RangeEventContext> const&)`: called by range renderers during attachment.
- `ObservedContainer::readerContextCount()`: raw size of the reader vector (debug/test helper).
- `RangeEventContext::setDisableOptimizations(bool)`: replaces the removed boolean constructor.

## Tests

- ~24 new `MultiSubscriber_*` tests covering every mutating op (push/pop front+back, emplace, insert ×4 overloads, erase ×2, resize ×3, indexed-assign, iterator-deref-assign, swap, assign, full reassignment, clear+repopulate).
- 8 lifecycle/stress tests: `SubscriberLifetime_Detach`, `SubscriberLifetime_DiesMidBroadcast`, `FiveSubscribers_RandomMutations`, `InteractionAcrossSubscribers`, `OperatorAssignBetweenContainers`, `Map_Set_Deque_MultiSubscriber`, `MoveAssignedObservedHasNoSubscribers`, `RepeatedIndexedAssignAtSamePosition`.

## Test mock fixes

- `replaceWith` now actually replaces `self`'s entry in the parent's `children` / `childNodes` arrays (was previously redirecting `self`'s shared `ReferenceType`, which only worked for the first replace at any DOM position; subsequent replaces became invisible to the parent).
- `replaceWith`'s no-parent fallback (used for root `setBody`) also rebinds `document.body` to the new value when `self` is the current body, so chained body replacements within a single test no longer leave `document.body` pointing through a stale reference chain.

## Dependencies

- Bumped `interval-tree` to the latest pinned commit.

## Test results

**405 passing, 0 disabled**
