### PR TITLE
Fixed observed range rendering for shared_ptrs.

### DIFF
--- a/nui/include/nui/event_system/range.hpp
+++ b/nui/include/nui/event_system/range.hpp
@@ -90,7 +90,10 @@ namespace Nui
         using BasicObservedRange<ObservedRange<ObservedValue>>::before_;
         using BasicObservedRange<ObservedRange<ObservedValue>>::after_;
 
-        static constexpr bool isRandomAccess = ObservedType::isRandomAccess;
+        // Unwrap through shared_ptr/weak_ptr<Observed> so the trait reads from the
+        // underlying Observed rather than the smart pointer (which has no isRandomAccess).
+        static constexpr bool isRandomAccess =
+            Detail::ObservedAddMutableReference_raw<ObservedType>::isRandomAccess;
 
         template <typename ObservedValueT>
         requires std::is_same_v<std::decay_t<ObservedValueT>, std::decay_t<ObservedValueT>>
@@ -166,7 +169,24 @@ namespace Nui
         return ObservedRange<const ObservedValue>{observedValues};
     }
 
+    /**
+     * @brief Reactive range over a shared_ptr/weak_ptr<Observed<Container>>.
+     *
+     * The smart pointer is stored internally as a weak_ptr (matching how shared/weak
+     * observed are treated elsewhere), locked per update, so the range reacts to
+     * mutations and reassignment of the underlying Observed. The caller must keep the
+     * shared_ptr alive for as long as the rendered range is mounted. Taken by value so
+     * the weak_ptr conversion is well-formed for both shared_ptr and weak_ptr inputs.
+     */
+    template <typename ObservedValue>
+    requires(IsSharedObserved<ObservedValue> || IsWeakObserved<ObservedValue>)
+    ObservedRange<std::decay_t<ObservedValue>> range(ObservedValue observedValues)
+    {
+        return ObservedRange<std::decay_t<ObservedValue>>{std::move(observedValues)};
+    }
+
     template <typename ContainerT, typename... Observed>
+    requires(!IsObservedLike<std::remove_cvref_t<ContainerT>>)
     UnoptimizedRange<IteratorAccessor<ContainerT const>, std::decay_t<Detail::ObservedAddReference_t<Observed>>...>
     range(ContainerT const& container, Observed&&... observed)
     {
@@ -179,6 +199,7 @@ namespace Nui
     }
 
     template <typename ContainerT, typename... Observed>
+    requires(!IsObservedLike<std::remove_cvref_t<ContainerT>>)
     UnoptimizedRange<IteratorAccessor<ContainerT>, std::decay_t<Detail::ObservedAddReference_t<Observed>>...>
     range(ContainerT& container, Observed&&... observed)
     {
@@ -237,6 +258,7 @@ namespace Nui
     }
 
     template <typename ContainerT>
+    requires(!IsObservedLike<std::remove_cvref_t<ContainerT>>)
     UnoptimizedRange<IteratorAccessor<ContainerT const>> range(ContainerT const& container)
     {
         return UnoptimizedRange<IteratorAccessor<ContainerT const>>{
@@ -250,7 +272,7 @@ namespace Nui
      *        even if the caller's local container goes out of scope immediately.
      */
     template <typename ContainerT>
-    requires(!IsObserved<std::remove_cvref_t<ContainerT>>)
+    requires(!IsObservedLike<std::remove_cvref_t<ContainerT>>)
     UnoptimizedRange<OwningIteratorAccessor<std::remove_cvref_t<ContainerT>>>
     range(ContainerT&& container)
     {
@@ -262,6 +284,7 @@ namespace Nui
 
 #ifdef NUI_HAS_STD_RANGES
     template <typename T, typename... Observed>
+    requires(!IsObservedLike<std::remove_cvref_t<T>>)
     UnoptimizedRange<
         std::ranges::subrange<std::ranges::iterator_t<T const>>,
         std::decay_t<Detail::ObservedAddReference_t<Observed>>...> range(T const& container, Observed&&... observed)

--- a/nui/include/nui/frontend/elements/impl/range_renderer.tpp
+++ b/nui/include/nui/frontend/elements/impl/range_renderer.tpp
@@ -61,9 +61,10 @@ namespace Nui::Detail
                     return &valueRange;
                 },
                 [&holder](::Nui::IsWeakObserved auto& valueRange) {
-                    if (holder.locked = valueRange.lock(); holder.locked)
-                        return holder.locked.get();
-                    return nullptr;
+                    holder.locked = valueRange.lock();
+                    // get() yields nullptr when the weak_ptr could not be locked; both
+                    // overloads must return the same Observed* type for auto deduction.
+                    return holder.locked.get();
                 },
             }(valueRange_);
         }
@@ -208,8 +209,7 @@ namespace Nui::Detail
             if (!parent)
                 return InvalidateRange;
 
-            auto valueRangeHolder =
-                ::Nui::Detail::HoldToken<std::decay_t<ObservedAddMutableReference_t<typename RangeT::ObservedType>>>{};
+            auto valueRangeHolder = CommonHoldToken<RangeT>{};
             auto* valueRange = getValueRange(valueRangeHolder);
             if (!valueRange)
                 return InvalidateRange;

--- a/nui/test/nui/test_ranges.hpp
+++ b/nui/test/nui/test_ranges.hpp
@@ -50,6 +50,68 @@ namespace Nui::Tests
         textBodyParityTest(vec, parent);
     }
 
+    // range() over a shared_ptr<Observed<...>> must be reactive (stored as a weak_ptr
+    // internally, locked per update). Reassigning the underlying Observed re-renders.
+    TEST_F(TestRanges, SharedPtrObservedReassignmentUpdatesView)
+    {
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+
+        Nui::val parent;
+        auto vec = std::make_shared<Observed<std::vector<char>>>(std::vector<char>{'A', 'B', 'C', 'D'});
+
+        render(body{reference = parent}(range(vec), [](long long, auto const& element) {
+            return div{}(std::string{element});
+        }));
+        textBodyParityTest(*vec, parent);
+
+        *vec = std::vector<char>{'X', 'Y', 'Z'};
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(*vec, parent);
+    }
+
+    // Element-level mutation (push_back) through the shared_ptr also re-renders.
+    TEST_F(TestRanges, SharedPtrObservedPushBackUpdatesView)
+    {
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+
+        Nui::val parent;
+        auto vec = std::make_shared<Observed<std::vector<char>>>(std::vector<char>{'A', 'B'});
+
+        render(body{reference = parent}(range(vec), [](long long, auto const& element) {
+            return div{}(std::string{element});
+        }));
+        textBodyParityTest(*vec, parent);
+
+        vec->push_back('C');
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(*vec, parent);
+    }
+
+    // weak_ptr<Observed<...>> is accepted too; it reacts while the owner keeps it alive.
+    TEST_F(TestRanges, WeakPtrObservedUpdatesView)
+    {
+        using Nui::Elements::div;
+        using Nui::Elements::body;
+        using namespace Nui::Attributes;
+
+        Nui::val parent;
+        auto vec = std::make_shared<Observed<std::vector<char>>>(std::vector<char>{'A', 'B', 'C', 'D'});
+        std::weak_ptr<Observed<std::vector<char>>> weak = vec;
+
+        render(body{reference = parent}(range(weak), [](long long, auto const& element) {
+            return div{}(std::string{element});
+        }));
+        textBodyParityTest(*vec, parent);
+
+        vec->push_back('E');
+        globalEventContext.executeActiveEventsImmediately();
+        textBodyParityTest(*vec, parent);
+    }
+
     TEST_F(TestRanges, PushBackUpdatesView)
     {
         Nui::val parent;


### PR DESCRIPTION
Using a shared_ptr<Observed<std::vector<T>>> in a range() was taking a wrong overload leading to unobserved range rendering.